### PR TITLE
update configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,14 @@
       "git diff --exit-code --quiet"
     ]
   },
+  "postcss": {
+    "plugins": {
+      "postcss-custom-properties": {},
+      "postcss-import": {},
+      "autoprefixer": {},
+      "postcss-single-charset": {}
+    }
+  },
   "private": true,
   "repository": "openameba/a11y-guidelines",
   "scripts": {
@@ -55,8 +63,8 @@
     "fixpack": "npx fixpack",
     "start": "hugo serve || docker-compose run --rm --service-ports serve",
     "styles": "npm run styles:default && npm run styles:detail",
-    "styles:default": "postcss -c ./postcss.config.js ./src/styles/default.css -o ./static/css/default.css",
-    "styles:detail": "postcss -c ./postcss.config.js ./src/styles/detail.css -o ./static/css/detail.css",
+    "styles:default": "postcss ./src/styles/default.css -o ./static/css/default.css",
+    "styles:detail": "postcss ./src/styles/detail.css -o ./static/css/detail.css",
     "test": "npm run textlint",
     "textlint": "textlint content src",
     "textlint:fix": "textlint --fix content src",

--- a/package.json
+++ b/package.json
@@ -35,13 +35,12 @@
   ],
   "license": "MIT",
   "lint-staged": {
-    "*.@(md)": [
-      "test",
-      "textlint --fix",
-      "git add"
+    "*.md": [
+      "npm run textlint",
+      "git diff --exit-code --quiet"
     ],
     "package.json": [
-      "npm run fixpack",
+      "npx fixpack",
       "git diff --exit-code --quiet"
     ]
   },

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,8 +1,0 @@
-module.exports = {
-  plugins: [
-    require('postcss-custom-properties')(),
-    require('postcss-import')(),
-    require('autoprefixer')(),
-    require('postcss-single-charset')(),
-  ]
-};


### PR DESCRIPTION
## チェック項目

Pull Request を出す前に確認しましょう

- [x] Pull Request の概要を適切に書いた
- [x] レビュアの指定をしている
- [x] textlintを実行しエラーが出ていない

---

## 概要

おもむろにpostcss.config.jsの設定をpackage.jsonに入れるようにしました（設定ファイルが少ない印象 + package.jsonに集めたい印象があったので）。

CSSのビルドをしてエラーが出ず、差分がなかったので恐らく大丈夫かと思います。

testのワークフローにビルドなども含めた方が、renovateが出したPRでビルドできなくなったりしたことを検出できていいかもしれないですね、とちょっと思いました。