### PR TITLE
renovateのPRに自動でassignする

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,32 @@
+# Set to true to add reviewers to pull requests
+addReviewers: false
+
+# Set to true to add assignees to pull requests
+addAssignees: true
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers:
+# - reviewerA
+# - reviewerB
+# - reviewerC
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0
+
+# A list of assignees, overrides reviewers if set
+assignees:
+  - herablog
+  - hrfmmymt
+  - nagatsukey
+  - sasaplus1
+  - tokimari
+
+# A number of assignees to add to the pull request
+# Set to 0 to add all of the assignees.
+# Uses numberOfReviewers if unset.
+numberOfAssignees: 2
+
+# A list of keywords to be skipped the process that add reviewers if pull requests include it
+# skipKeywords:
+#   - wip

--- a/.github/workflows/auto-assign-to-renovate.yml
+++ b/.github/workflows/auto-assign-to-renovate.yml
@@ -1,0 +1,15 @@
+name: Auto assign to renovate PR
+
+on:
+  pull_request:
+    branches:
+      - renovate/*
+
+jobs:
+  auto-assign:
+    name: auto assign
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v1.0.1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -6,12 +6,5 @@
     ":label(renovate)",
     ":preserveSemverRanges",
     ":timezone(Asia/Tokyo)"
-  ],
-  "assignees": [
-    "herablog",
-    "hrfmmymt",
-    "nagatsukey",
-    "sasaplus1",
-    "tokimari"
   ]
 }


### PR DESCRIPTION
## チェック項目

Pull Request を出す前に確認しましょう

- [x] Pull Request の概要を適切に書いた
- [x] レビュアの指定をしている
- [x] textlintを実行しエラーが出ていない

---

## 概要

close #30 

renovateのPRに自動で2人assignするGitHub Actionを追加しました。

PRが生成されたとき`renovate/*`という名前のブランチだった場合に https://github.com/kentaro-m/auto-assign-action を実行するというシンプルなものです。とりあえず2人指定するようにしています。