### PR TITLE
refactor: set default language

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -16,3 +16,4 @@ summaryLength: 130
 disableKinds:
   - taxonomy
   - taxonomyTerm
+DefaultContentLanguage: ja

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="ja">
+<html lang="{{ .Lang }}">
   <head>
     {{ partial "meta.html" . }}
   </head>


### PR DESCRIPTION
## チェック項目

Pull Request を出す前に確認しましょう

- [x] Pull Request の概要を適切に書いた
- [x] レビュアの指定をしている
- textlintを実行しエラーが出ていない

---

## 概要
ビルド時の言語が`EN`になっていたので、デフォルトの言語を日本語`ja`で指定し、HTMLのlang属性の値として利用するように変更しました。生成されるファイルに変更はありません。

<img width="180" alt="Hugoでサイトをビルドしたときのコンソール出力。ファイルの言語として「EN」と表示されている。" src="https://user-images.githubusercontent.com/869023/71434648-c37ac700-2728-11ea-8605-7deb0b7433ac.png">


## 確認すること

ビルド時の言語が`JA`になっている。

<img width="198" alt="Hugoでサイトをビルドしたときのコンソール出力。ファイルの言語として「JA」と表示されている。" src="https://user-images.githubusercontent.com/869023/71434476-12742c80-2728-11ea-88fa-5342f9cfedd9.png">

生成されたHTMLのlang属性の値が、`ja`である。
<img width="213" alt="HTMLファイルをChrome DevToolsで開いたスクリーンショット。lang='ja'として出力されている。" src="https://user-images.githubusercontent.com/869023/71434551-6848d480-2728-11ea-90da-73b51210052f.png">

