### PR TITLE
fix: figure, video shortcodeのcaption条件分岐を修正

### DIFF
--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -12,16 +12,14 @@
       />
     {{ end  }}
     {{ if .Get "src2" }}</div>{{ end }}
-    {{ if or (.Get .Inner) (.Get "rule") }}
-      <figcaption>
-        {{ if .Get "rule" }}
-          <span class="RuleLabel RuleLabel--{{ .Get "rule" }}">
-            <img src="{{ .Site.BaseURL }}/img/icon/{{ .Get "rule" }}.svg" width="24" height="24" alt="" />
-            {{ if .Get "rule" | eq "bad" }}Bad{{ else if .Get "rule" | eq "good" }}Good{{ end }}
-          </span>
-        {{ end }}
-        {{ .Inner }}
-      </figcaption>
-    {{ end }}
+    <figcaption>
+      {{ if .Get "rule" }}
+        <span class="RuleLabel RuleLabel--{{ .Get "rule" }}">
+          <img src="{{ .Site.BaseURL }}/img/icon/{{ .Get "rule" }}.svg" width="24" height="24" alt="" />
+          {{ if .Get "rule" | eq "bad" }}Bad{{ else if .Get "rule" | eq "good" }}Good{{ end }}
+        </span>
+      {{ end }}
+      {{ .Inner }}
+    </figcaption>
   </figure>
 {{ if .Get "isList" }}</li>{{ end }}

--- a/layouts/shortcodes/video.html
+++ b/layouts/shortcodes/video.html
@@ -6,16 +6,14 @@
         <track label="Japan" kind="captions" srclang="ja" src="{{ .Get "captionSrc" }}" />
       {{ end }}
     </video>
-    {{ if or (.Get .Inner) (.Get "rule") }}
-      <figcaption>
-        {{ if .Get "rule" }}
-          <span class="RuleLabel RuleLabel--{{ .Get "rule" }}">
-            <img src="{{ .Site.BaseURL }}/img/icon/{{ .Get "rule" }}.svg" width="24" height="24" alt="" />
-            {{ if .Get "rule" | eq "bad" }}Bad{{ else if .Get "rule" | eq "good" }}Good{{ end }}
-          </span>
-        {{ end }}
-        {{ .Inner }}
-      </figcaption>
-    {{ end }}
+    <figcaption>
+      {{ if .Get "rule" }}
+        <span class="RuleLabel RuleLabel--{{ .Get "rule" }}">
+          <img src="{{ .Site.BaseURL }}/img/icon/{{ .Get "rule" }}.svg" width="24" height="24" alt="" />
+          {{ if .Get "rule" | eq "bad" }}Bad{{ else if .Get "rule" | eq "good" }}Good{{ end }}
+        </span>
+      {{ end }}
+      {{ .Inner }}
+    </figcaption>
   </figure>
 {{ if .Get "isList" }}</li>{{ end }}


### PR DESCRIPTION
## チェック項目

Pull Request を出す前に確認しましょう

- [x] Pull Request の概要を適切に書いた
- [x] レビュアの指定をしている
- [x] textlintを実行しエラーが出ていない

---

## 概要

ref: https://github.com/openameba/a11y-guidelines/pull/35#issuecomment-571933350

```
$ docker-compose run --rm serve
Building sites … WARN 2020/01/08 07:54:14 found no layout file for "HTML" for "section": You should create a template file which matches Hugo Layouts Lookup Rules for this combination.
Built in 401 ms
Error: Error building site: "/var/www/a11y-guidelines/content/2/2/2.md:35:1": failed to render shortcode "figurelist": failed to process shortcode: "/var/www/a11y-guidelines/layouts/shortcodes/figure.html:15:14": execute of template failed: template: shortcodes/figure.html:15:14: executing "shortcodes/figure.html" at <.Get>: error calling Get: reflect: call of reflect.Value.Interface on zero Value
```
https://github.com/openameba/a11y-guidelines/pull/35 でversion上がったら出るようになったエラーなので、定かではないですが・・

shortcodeの `.Inner` が設定されてるか否かの判定式はそもそもなかったので削除。Inner（＝caption相当）は全て設定したいので判定自体削除しました。