### PR TITLE
add forceOrphan option to actions-gh-pages

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -30,3 +30,5 @@ jobs:
           ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           PUBLISH_BRANCH: gh-pages
           PUBLISH_DIR: ./public
+        with:
+          forceOrphan: true


### PR DESCRIPTION
## チェック項目

Pull Request を出す前に確認しましょう

- [x] Pull Request の概要を適切に書いた
- [x] レビュアの指定をしている
- textlintを実行しエラーが出ていない

---

## 概要

peaceiris/actions-gh-pages@v2 では `forceOrphan` が指定でき、これにより常にgh-pagesブランチのコミットを1つだけにできるようだったので指定してみました。
これまでwerckerでデプロイ-paしていたときと同じ挙動になるかと思います。

gh-pagesブランチがそんなにコミット増えても嬉しくないのでこちらの方が良いかなあと。