### PR TITLE
feat: twitter card larger

### DIFF
--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -46,7 +46,7 @@
   <meta property="og:title" content="{{ .Site.Title }}">
 {{ end }}
 
-<meta name="twitter:card" content="summary">
+<meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:site" content="@ameba_official">
 
 <link rel="canonical" href="{{ .Permalink }}">


### PR DESCRIPTION
## チェック項目

Pull Request を出す前に確認しましょう

- [x] Pull Request の概要を適切に書いた
- [x] レビュアの指定をしている
- [x] textlintを実行しエラーが出ていない

---

## 概要

Twitterでシェアしたときに見切れてしまっていたので、大きな画像で見えるようにしました。

<img width="567" alt="ガイドライン1.1.1のTwitterでシェアしたプレビュー。タイトルが見切れている。" src="https://user-images.githubusercontent.com/6724665/92919344-44baeb00-f46b-11ea-8db2-7aaab4d5e6ef.png">

