### PR TITLE
fix: summaryのoutlineを調整

### DIFF
--- a/src/styles/detail/details.css
+++ b/src/styles/detail/details.css
@@ -50,9 +50,14 @@ summary:after {
   background: url('/a11y-guidelines/img/icon/open.svg') no-repeat 0 center;
   background-size: 16px;
 }
+
 details[open] > summary:after {
   position: absolute;
   content: '';
   background: url('/a11y-guidelines/img/icon/close.svg') no-repeat 0 center;
   background-size: 16px;
+}
+
+summary:focus {
+  outline-offset: 1px;
 }


### PR DESCRIPTION
## チェック項目

Pull Request を出す前に確認しましょう

- [x] Pull Request の概要を適切に書いた
- [x] レビュアの指定をしている
- [x] textlintを実行しエラーが出ていない

---

## 概要
chromeで閲覧していた際、outlineのレイアウトが欠落していたが気になって修正したのですがどうでしょうか。
`outline-offset` なのでブラウザによって多少解釈が違ったりもしますが枠のエリアを少し変更したので問題ないかと。

あとついでに修正したcssの改行が統一されていなさそうだったので合わせて修正しました。


## スクリーンショット

### Before
<img width="769" alt="スクリーンショット 2020-10-21 16 58 39" src="https://user-images.githubusercontent.com/14571646/96695332-7dcc7080-13c4-11eb-93d8-b61ffd83df20.png">

### After

#### chrome
<img width="764" alt="スクリーンショット 2020-10-21 16 59 06" src="https://user-images.githubusercontent.com/14571646/96695348-845ae800-13c4-11eb-9dc2-6464071de818.png">

#### safari
<img width="754" alt="スクリーンショット 2020-10-21 17 36 50" src="https://user-images.githubusercontent.com/14571646/96695546-bb30fe00-13c4-11eb-926f-4d7445d858bb.png">
