### PR TITLE
fix: remove renovate assignees member

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,13 +65,11 @@
     ],
     "assignees": [
       "herablog",
-      "hiloki",
       "hrfmmymt",
       "masuP9",
       "nagatsukey",
       "sasaplus1",
-      "syasuda90",
-      "tokimari"
+      "syasuda90"
     ],
     "assigneesSampleSize": 2
   },


### PR DESCRIPTION
## チェック項目

Pull Request を出す前に確認しましょう
- [x] Pull Request の概要を適切に書いた
- [x] レビュアの指定をしている
- [x] textlintを実行しエラーが出ていない

## 概要
`renovate` にアサインされるメンバーを一部除外しました。
必要でしたら追加できそうなメンバーを検討したい所存です。