### PR TITLE
chore: add postcss group to renovate

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "extends": [
       "config:base",
       "group:linters",
+      "group:postcss",
       ":automergePatch",
       ":label(renovate)",
       ":preserveSemverRanges",


### PR DESCRIPTION
## チェック項目

Pull Request を出す前に確認しましょう

- [x] Pull Request の概要を適切に書いた
- [x] レビュアの指定をしている
- [x] textlintを実行しエラーが出ていない

---

## 概要

renovateに`group:postcss`を追加しました。これにより #122 #105 のような、一緒にアップデートされた方が嬉しいモジュールのPull-requestが作られるような気がします。