### PR TITLE
代替テキストの決定ツリーを追加

### DIFF
--- a/content/1/1/1.md
+++ b/content/1/1/1.md
@@ -134,3 +134,194 @@ WAI-ARIAの `aria-label` 属性、`role` 属性を設定する
 - [H36: 送信 / 実行ボタンとして用いる画像の alt 属性を使用する | WCAG 2.0 達成方法集](http://waic.jp/docs/WCAG-TECHS/H36.html)
 - [ARIA15: 画像の説明を提供するために aria-describedby を使用する | WCAG 2.0 達成方法集](http://waic.jp/docs/WCAG-TECHS/ARIA15)
 - [H2: 隣り合った画像とテキストリンクを同じリンクの中に入れる | WCAG 2.0 達成方法集](https://waic.jp/docs/WCAG-TECHS/H2.html)
+
+## 代替テキスト決定ツリー
+
+### 文字がある
+
+<div class="AltTree">
+  <table>
+    <thead>
+      <tr>
+        <th>画像の種別</th>
+        <th>画像例</th>
+        <th>代替テキストに設定すべき内容</th>
+        <th>代替テキストの例</th>
+        <th>状態</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th>隣接するテキストと重複</th>
+        <td>画像1</td>
+        <td>
+          空<br>
+          （図／グラフなど複雑な場合は＊参照）
+        </td>
+        <td>alt = ""</td>
+        <td>NO</td>
+      </tr>
+      <tr>
+        <th>機能を示すグラフィックと文字</th>
+        <td>画像2</td>
+        <td>機能説明</td>
+        <td>alt = "ホーム"</td>
+        <td>NO</td>
+      </tr>
+      <tr>
+        <th>文字画像</th>
+        <td>画像3</td>
+        <td>画像中の文字</td>
+        <td>alt = "ホーム"</td>
+        <td>NO</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+### リンク／ボタン 
+
+<div class="AltTree">
+  <table>
+    <thead>
+      <tr>
+        <th>画像の種別</th>
+        <th>画像例</th>
+        <th>代替テキストに設定すべき内容</th>
+        <th>代替テキストの例</th>
+        <th>状態</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th>シンプルなグラフィック／写真</th>
+        <td>画像1</td>
+        <td>
+          リンク先のタイトル<br>
+          ボタンの機能
+        </td>
+        <td>
+          alt = "ホーム"<br>
+          alt = "印刷"
+        </td>
+        <td>NO</td>
+      </tr>
+      <tr>
+        <th>イメージマップ</th>
+        <td>画像2</td>
+        <td>
+          img 要素：マップ全体の説明<br>
+          area 要素：個々のリンク先
+        </td>
+        <td>
+          alt = "日本全体の店舗マップ"<br>
+          alt = "北海道"
+        </td>
+        <td>NO</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+### 意味がある
+
+<div class="AltTree">
+  <table>
+    <thead>
+      <tr>
+        <th>画像の種別</th>
+        <th>画像例</th>
+        <th>代替テキストに設定すべき内容</th>
+        <th>代替テキストの例</th>
+        <th>状態</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th>シンプルなグラフィック／写真</th>
+        <td>画像1</td>
+        <td>簡潔な説明</td>
+        <td>alt = "電話番号"</td>
+        <td>NO</td>
+      </tr>
+      <tr>
+        <th>複雑な図／グラフ／写真＊</th>
+        <td>画像2</td>
+        <td>
+          画像に含まれている全ての情報<br>
+          書き切れない場合は主旨説明<br>
+          （本文テキストや表での説明も有効）
+        </td>
+        <td>alt = "～のグラフ：2015年は nn、<br>2016年は nn、2017年は nn、2018年は<br>nnと年々好調に伸びています"</td>
+        <td>NO</td>
+      </tr>
+      <tr>
+        <th>隣接するテキストの補足＊＊</th>
+        <td>画像3</td>
+        <td>テキストで説明されていない内容</td>
+        <td>alt = "イラスト：年老いた灰色の猫"</td>
+        <td>NO</td>
+      </tr>
+      <tr>
+        <th>隣接するテキストと重複</th>
+        <td>画像4</td>
+        <td>
+          空<br>
+          （補足する内容がある場合は＊＊参照）
+        </td>
+        <td>alt = ""</td>
+        <td>NO</td>
+      </tr>
+      <tr>
+        <th>コンテンツの印象や感情を伝える画像</th>
+        <td>画像5</td>
+        <td>印象を伝える説明</td>
+        <td>alt = "イラスト：猫の不安そうな眼差し"</td>
+        <td>NO</td>
+      </tr>
+      <tr>
+        <th>画像グループ</th>
+        <td>画像6</td>
+        <td>1枚で全体を説明</td>
+        <td>
+          alt = "星二つ"<br>
+          alt = ""<br>
+          alt = ""
+        </td>
+        <td>NO</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+### 装飾画像
+
+<div class="AltTree">
+  <table>
+    <thead>
+      <tr>
+        <th>画像の種別</th>
+        <th>画像例</th>
+        <th>代替テキストに設定すべき内容</th>
+        <th>代替テキストの例</th>
+        <th>状態</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th>ページデザインの一部</th>
+        <td>画像1</td>
+        <td>空</td>
+        <td>alt = ""</td>
+        <td>NO</td>
+      </tr>
+      <tr>
+        <th>ページの雰囲気を表現した画像</th>
+        <td>画像2</td>
+        <td>空</td>
+        <td>alt = ""</td>
+        <td>NO</td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/content/1/1/1.md
+++ b/content/1/1/1.md
@@ -137,22 +137,21 @@ WAI-ARIAの `aria-label` 属性、`role` 属性を設定する
 
 ## 代替テキスト決定ツリー
 
-### 文字がある
-
 <div class="AltTree">
   <table>
+    <caption>文字がある</caption>
     <thead>
       <tr>
-        <th>画像の種別</th>
-        <th>画像例</th>
-        <th>代替テキストに設定すべき内容</th>
-        <th>代替テキストの例</th>
-        <th>状態</th>
+        <th scope="col">画像の種別</th>
+        <th scope="col">画像例</th>
+        <th scope="col">代替テキストに設定すべき内容</th>
+        <th scope="col">代替テキストの例</th>
+        <th scope="col">状態</th>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <th>隣接するテキストと重複</th>
+        <th scope="row">隣接するテキストと重複</th>
         <td>画像1</td>
         <td>
           空<br>
@@ -162,14 +161,14 @@ WAI-ARIAの `aria-label` 属性、`role` 属性を設定する
         <td>NO</td>
       </tr>
       <tr>
-        <th>機能を示すグラフィックと文字</th>
+        <th scope="row">機能を示すグラフィックと文字</th>
         <td>画像2</td>
         <td>機能説明</td>
         <td>alt = "ホーム"</td>
         <td>NO</td>
       </tr>
       <tr>
-        <th>文字画像</th>
+        <th scope="row">文字画像</th>
         <td>画像3</td>
         <td>画像中の文字</td>
         <td>alt = "ホーム"</td>
@@ -179,22 +178,21 @@ WAI-ARIAの `aria-label` 属性、`role` 属性を設定する
   </table>
 </div>
 
-### リンク／ボタン 
-
 <div class="AltTree">
   <table>
+    <caption>リンク／ボタン</caption>
     <thead>
       <tr>
-        <th>画像の種別</th>
-        <th>画像例</th>
-        <th>代替テキストに設定すべき内容</th>
-        <th>代替テキストの例</th>
-        <th>状態</th>
+        <th scope="col">画像の種別</th>
+        <th scope="col">画像例</th>
+        <th scope="col">代替テキストに設定すべき内容</th>
+        <th scope="col">代替テキストの例</th>
+        <th scope="col">状態</th>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <th>シンプルなグラフィック／写真</th>
+        <th scope="row">シンプルなグラフィック／写真</th>
         <td>画像1</td>
         <td>
           リンク先のタイトル<br>
@@ -207,7 +205,7 @@ WAI-ARIAの `aria-label` 属性、`role` 属性を設定する
         <td>NO</td>
       </tr>
       <tr>
-        <th>イメージマップ</th>
+        <th scope="row">イメージマップ</th>
         <td>画像2</td>
         <td>
           img 要素：マップ全体の説明<br>
@@ -223,29 +221,28 @@ WAI-ARIAの `aria-label` 属性、`role` 属性を設定する
   </table>
 </div>
 
-### 意味がある
-
 <div class="AltTree">
   <table>
+    <caption>意味がある</caption>
     <thead>
       <tr>
-        <th>画像の種別</th>
-        <th>画像例</th>
-        <th>代替テキストに設定すべき内容</th>
-        <th>代替テキストの例</th>
-        <th>状態</th>
+        <th scope="col">画像の種別</th>
+        <th scope="col">画像例</th>
+        <th scope="col">代替テキストに設定すべき内容</th>
+        <th scope="col">代替テキストの例</th>
+        <th scope="col">状態</th>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <th>シンプルなグラフィック／写真</th>
+        <th scope="row">シンプルなグラフィック／写真</th>
         <td>画像1</td>
         <td>簡潔な説明</td>
         <td>alt = "電話番号"</td>
         <td>NO</td>
       </tr>
       <tr>
-        <th>複雑な図／グラフ／写真＊</th>
+        <th scope="row">複雑な図／グラフ／写真＊</th>
         <td>画像2</td>
         <td>
           画像に含まれている全ての情報<br>
@@ -256,14 +253,14 @@ WAI-ARIAの `aria-label` 属性、`role` 属性を設定する
         <td>NO</td>
       </tr>
       <tr>
-        <th>隣接するテキストの補足＊＊</th>
+        <th scope="row">隣接するテキストの補足＊＊</th>
         <td>画像3</td>
         <td>テキストで説明されていない内容</td>
         <td>alt = "イラスト：年老いた灰色の猫"</td>
         <td>NO</td>
       </tr>
       <tr>
-        <th>隣接するテキストと重複</th>
+        <th scope="row">隣接するテキストと重複</th>
         <td>画像4</td>
         <td>
           空<br>
@@ -273,14 +270,14 @@ WAI-ARIAの `aria-label` 属性、`role` 属性を設定する
         <td>NO</td>
       </tr>
       <tr>
-        <th>コンテンツの印象や感情を伝える画像</th>
+        <th scope="row">コンテンツの印象や感情を伝える画像</th>
         <td>画像5</td>
         <td>印象を伝える説明</td>
         <td>alt = "イラスト：猫の不安そうな眼差し"</td>
         <td>NO</td>
       </tr>
       <tr>
-        <th>画像グループ</th>
+        <th scope="row">画像グループ</th>
         <td>画像6</td>
         <td>1枚で全体を説明</td>
         <td>
@@ -294,29 +291,28 @@ WAI-ARIAの `aria-label` 属性、`role` 属性を設定する
   </table>
 </div>
 
-### 装飾画像
-
 <div class="AltTree">
   <table>
+    <caption>装飾画像</caption>
     <thead>
       <tr>
-        <th>画像の種別</th>
-        <th>画像例</th>
-        <th>代替テキストに設定すべき内容</th>
-        <th>代替テキストの例</th>
-        <th>状態</th>
+        <th scope="col">画像の種別</th>
+        <th scope="col">画像例</th>
+        <th scope="col">代替テキストに設定すべき内容</th>
+        <th scope="col">代替テキストの例</th>
+        <th scope="col">状態</th>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <th>ページデザインの一部</th>
+        <th scope="row">ページデザインの一部</th>
         <td>画像1</td>
         <td>空</td>
         <td>alt = ""</td>
         <td>NO</td>
       </tr>
       <tr>
-        <th>ページの雰囲気を表現した画像</th>
+        <th scope="row">ページの雰囲気を表現した画像</th>
         <td>画像2</td>
         <td>空</td>
         <td>alt = ""</td>

--- a/src/styles/detail/alt_tree.css
+++ b/src/styles/detail/alt_tree.css
@@ -1,0 +1,36 @@
+/**
+ * AltTree
+ */
+.AltTree {
+  border-collapse: collapse;
+  display: block;
+  overflow-x: scroll;
+  white-space: nowrap;
+  -webkit-overflow-scrolling: touch;
+}
+
+.AltTree table {
+  width: 100%;
+  position: relative;
+}
+
+.AltTree table tbody {
+  position: relative;
+}
+
+.AltTree table thead th,
+.AltTree table thead td {
+  padding: 8px;
+  margin: 0;
+  text-align: left;
+  font-size: calc(16 / 16 * 1rem);
+}
+
+.AltTree table tbody th,
+.AltTree table tbody td {
+  padding: 8px;
+  margin: 0;
+  border-top: 1px solid var(--color-border-low-emphasis);
+  text-align: left;
+  font-size: calc(12 / 16 * 1rem);
+}

--- a/src/styles/detail/alt_tree.css
+++ b/src/styles/detail/alt_tree.css
@@ -9,6 +9,16 @@
   -webkit-overflow-scrolling: touch;
 }
 
+.AltTree + .AltTree {
+  margin-top: 32px;
+}
+
+.AltTree caption {
+  font-size: calc(18 / 16 * 1rem);
+  line-height: 1.71;
+  text-align: left;
+}
+
 .AltTree table {
   width: 100%;
   position: relative;

--- a/src/styles/detail/index.css
+++ b/src/styles/detail/index.css
@@ -4,3 +4,4 @@
 @import "./code.css";
 @import "./details.css";
 @import "./heading.css";
+@import "./alt_tree.css";


### PR DESCRIPTION
## チェック項目

Pull Request を出す前に確認しましょう

- [x] Pull Request の概要を適切に書いた
- [x] レビュアの指定をしている
- [x] textlintを実行しエラーが出ていない

---

## 概要
[こちらのissue](https://github.com/openameba/a11y-guidelines/issues/7) にある代替テキストの付け方の説明を追加するの対応を行いました。
エイヤという感じでマークアップしたのでまだ草案 or モックレベルという温度感ではあります。
ですのでいくつか相談しつつ作り上げていきたい所存です。

決定木の項目等に関しては[こちら](https://sawada-std-design.com/works/readable-na/readable-na-alt-decision-tree-20181105.pdf) を参考（許可を得て）にしつつAmebaライクなものに仕上げていこうと思っています。


## スクリーンショット
<img width="521" alt="スクリーンショット 2020-11-26 16 00 38" src="https://user-images.githubusercontent.com/14571646/100318202-014f3200-3001-11eb-94aa-845972858d6c.png">

このような形で現在は `1.1.1 画像に代替テキストを提供する` の最下部に配置しています。

## マージするまでに達成すること
- [ ] 決定ツリーの見た目Fix
- [ ] 決定ツリーをどこに配置するか
- [ ] css（class名など）やhtmlの配置に関するルールが適切に対応できているか