### PR TITLE
比較画像にthrobberが映らないようにした

### DIFF
--- a/npm_scripts/scrape.js
+++ b/npm_scripts/scrape.js
@@ -29,7 +29,14 @@ async function capture(pathnames) {
 
     await fs.mkdir(dir, { recursive: true });
 
-    await page.goto(url.toString(), { waitUntil: 'load' });
+    await page.goto(url.toString(), { waitUntil: 'networkidle0' });
+
+    const videos = await page.$$('video');
+
+    if (videos.length > 0) {
+      await page.waitForTimeout(1000);
+    }
+
     await page.screenshot({
       fullPage: true,
       path: output


### PR DESCRIPTION
## チェック項目

Pull Request を出す前に確認しましょう

- [x] Pull Request の概要を適切に書いた
- [x] レビュアの指定をしている
- textlintを実行しエラーが出ていない

---

## 概要

https://github.com/openameba/a11y-guidelines/pull/142#issuecomment-747291841 で発生しましたが、動画が存在するページでthrobberが映り込んでしまって毎回diffが出てしまう、というのを修正しました。

videoのタグがページに存在する場合は数百ミリ秒待つことにしました。 `preload="none"` や `metadata` でも試してみましたが、くるくるが写ってしまうようでした。

お手元で試す場合は以下のようにするとスクリーンショットが取得できるかと思います。

```console
$ npm install -D puppeteer
$ node ./npm_scripts/scrape.js "${PWD}/.reg-suit/actual_images" http://localhost:1313 /a11y-guidelines/2/2/2/index.html
```