### PR TITLE
スクリーンショットのフォントが豆腐になってしまうのを修正

### DIFF
--- a/.github/workflows/regression-test.yml
+++ b/.github/workflows/regression-test.yml
@@ -14,6 +14,7 @@ jobs:
           - 12
     runs-on: ubuntu-latest
     steps:
+      - run: sudo apt-get --yes install fonts-noto
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0


### PR DESCRIPTION
## チェック項目

Pull Request を出す前に確認しましょう

- [x] Pull Request の概要を適切に書いた
- [x] レビュアの指定をしている
- [x] textlintを実行しエラーが出ていない

---

## 概要

regression-testワークフローでは動作環境としてubuntu-latestを指定していますが、最近Ubuntuのバージョンがアップグレードされ、その影響により日本語フォントが入らなくなってしまったようです。なのでスクリーンショットを取得すると文字が豆腐になっていました。

豆腐のままでは困るのでワークフローの最初で日本語フォントをインストールするようにしました。フォントは名前の由来にぴったりなnotoフォントにしました。

https://storage.googleapis.com/a11y-guidelines/06b21deeebf22d92d206672569686c83375d5808/index.html?stat=q1ZKS8zMSU3xLEnNLXbOL80rUbIyNdVRykstRxYy0FFKSc1JLUFVCBQtSCwuRhOsBQA%3D