### PR TITLE
Amebaロゴに対してwidthとheightの指定を付与

### DIFF
--- a/src/_includes/partials/header.njk
+++ b/src/_includes/partials/header.njk
@@ -3,7 +3,7 @@
     <div class="Container">
       <h1>
         <a href="{{ site.baseURL }}">
-          <img src="{{ site.baseURL }}/img/logo.svg" class="Header__Logo" alt="Ameba" />
+          <img src="{{ site.baseURL }}/img/logo.svg" class="Header__Logo" alt="Ameba" width="157" height="60" />
           <span class="Header__title">Accessibility<br>Guidelines</span>
         </a>
       </h1>
@@ -11,7 +11,7 @@
   {% else %}
     <p class="Container">
       <a href="{{ site.baseURL }}">
-        <img src="{{ site.baseURL }}/img/logo.svg" class="Header__Logo" alt="Ameba" />
+        <img src="{{ site.baseURL }}/img/logo.svg" class="Header__Logo" alt="Ameba" width="157" height="60" />
         <span class="Header__title">Accessibility<br>Guidelines</span>
       </a>
     </p>

--- a/src/styles/common/header.css
+++ b/src/styles/common/header.css
@@ -20,7 +20,6 @@
 .Header__Logo {
   display: block;
   margin: 64px 0 48px;
-  width: 157px;
 }
 
 .Header__title {


### PR DESCRIPTION
## チェック項目
- [x] Pull Request の概要を適切に書いた
- [x] レビュアの指定をしている
- [x] textlintを実行しエラーが出ていない

## 概要
https://github.com/openameba/a11y-guidelines/issues/151
上記issueの対応を行いました。

## 変更後のスクリーンショット
<img width="1411" alt="スクリーンショット 2021-03-24 14 08 24" src="https://user-images.githubusercontent.com/14571646/112258915-ad9cde80-8caa-11eb-9ff1-042f96f8147f.png">
