### PR TITLE
chore: replace add-path

### DIFF
--- a/.github/workflows/publish-webbundle.yml
+++ b/.github/workflows/publish-webbundle.yml
@@ -34,7 +34,7 @@ jobs:
         # you can run setup-go action if you want to install specific version
         go get -u github.com/WICG/webpackage/go/bundle/cmd/gen-bundle
         # Add path to run the package
-        echo "::add-path::$HOME/go/bin"
+        echo "$HOME/go/bin" >> $GITHUB_PATH
 
     - name: Generate Web Bundle 📦
       run: |


### PR DESCRIPTION
## チェック項目

Pull Request を出す前に確認しましょう

- [x] Pull Request の概要を適切に書いた
- [x] レビュアの指定をしている
- [x] textlintを実行しエラーが出ていない

---

## 概要
Web Bundleを生成するスクリプトの中で、[廃止されたadd-pathコマンド](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)が使われていましたので、GitHubのドキュメント「[Adding a system path](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path)」を参考に置き換えました。

変更前に失敗したタスク: https://github.com/openameba/a11y-guidelines/runs/2189213933?check_suite_focus=true
変更して成功したタスク: https://github.com/openameba/a11y-guidelines/runs/2189257413?check_suite_focus=true
