### PR TITLE
fix: create CNAME file to public root

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -19,6 +19,9 @@ jobs:
           npm ci
           npm run build
 
+      - name: Create CNAME file to apply custom domain
+        run: echo 'a11y-guidelines.ameba.design' > public/CNAME
+
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
## チェック項目

Pull Request を出す前に確認しましょう

- [x] Pull Request の概要を適切に書いた
- [x] レビュアの指定をしている
- [x] textlintを実行しエラーが出ていない

---

## 概要
カスタムドメイン設定に必要なCNAMEファイルを、GitHub Pagesデプロイ時に生成するようにしました。毎回masterブランチからビルドされた`public`以下がgh-pagesブランチに反映されるため都度生成しています。

https://github.com/openameba/a11y-guidelines/blob/b8c429bddcaa9638e9d1d004dbec11d1d3b08906/.github/workflows/build-deploy.yml#L22-L28
