### PR TITLE
コードブロックにHTML指定を追加

### DIFF
--- a/src/1/4/10.md
+++ b/src/1/4/10.md
@@ -34,7 +34,7 @@ permalink: "{{ number | scNumberToPath }}/"
 - コンテンツを `position: absolute` などで固定する
 - 拡大・縮小を不可能にする指定をする
 
-```
+```html
 <meta name="viewport" content="width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no">
 ```
 

--- a/src/2/4/10.md
+++ b/src/2/4/10.md
@@ -28,7 +28,7 @@ permalink: "{{ number | scNumberToPath }}/"
 
 CSSなどで視覚的に見出しと判断できるような装飾を行っていたとしても、プログラム上からは解釈が出来ないためこの方法は不十分である。
 
-```
+```html
 <div>見出し１</div>
 <section>
   <div>本文タイトル</div>

--- a/src/2/5/3.md
+++ b/src/2/5/3.md
@@ -26,7 +26,7 @@ permalink: "{{ number | scNumberToPath }}/"
 #### 良い実装例
 
 aria-labelで表示されたテキストと視覚的に表示されるテキスト
-```
+```html
 <button aria-label="Go">Go</button>
 ```
 
@@ -34,7 +34,7 @@ aria-labelで表示されたテキストと視覚的に表示されるテキス�
 
 aria-labelで表示されたテキストは「Find in this site」だが、視覚的に表示されるテキストは「Go」で不一致。
 
-```
+```html
 <button aria-label="Find in this site">Go</button>
 ```
 

--- a/src/3/3/3.md
+++ b/src/3/3/3.md
@@ -45,7 +45,7 @@ ID・パスワード入力の回避方法を入れてはいけない。どちら
 
 `pattern`属性に含めた文字列（正規表現可）のみ送信できる。
 
-```
+```html
 <form>
   <label for="choose">What's name is this blog service?</label>
   <input id="choose" name="service_name" required pattern="ameba blog|ameblo">
@@ -66,7 +66,7 @@ pattern属性を用いた入力フォームの例。「ameba blog」と「ameblo
 
 `required`属性を持つ入力項目が空のとき、送信できない。
 
-```
+```html
 <form>
   <label for="choose">What's name is this blog service?</label>
   <input id="choose" name="service_name" required>

--- a/src/4/1/3.md
+++ b/src/4/1/3.md
@@ -45,7 +45,7 @@ permalink: "{{ number | scNumberToPath }}/"
 
 #### 良い実装例
 
-```
+```html
 <div id="error" role="alert" aria-live="assertive"></div>
 ```
 
@@ -55,7 +55,7 @@ permalink: "{{ number | scNumberToPath }}/"
 role属性をサポートしていないブラウザがあるので、WAI-ARIAの `aria-live="assertive"`も併用する。
 
 
-```
+```html
 <div id="error" role="alert"></div>
 ```
 


### PR DESCRIPTION
## 概要
dark modeのチェック時に一部マークダウンへのHTML指定がなかった箇所があったため修正いたしました。

## 関連するissue
https://github.com/openameba/a11y-guidelines/issues/202

## スクリーンショット

### Before
<img width="761" alt="スクリーンショット 2021-04-09 13 08 31" src="https://user-images.githubusercontent.com/14571646/114127775-db825400-9935-11eb-9f44-248dcc6c1618.png">

### After
<img width="750" alt="スクリーンショット 2021-04-09 13 08 23" src="https://user-images.githubusercontent.com/14571646/114127787-e2a96200-9935-11eb-98f0-45a963864cf6.png">

## チェック項目
- [x] Pull Request の概要を適切に書いた
- [x] レビュアの指定をしている
- [x] textlintを実行しエラーが出ていない