### PR TITLE
項目1.1.1の実装例を再考

### DIFF
--- a/src/1/1/1.md
+++ b/src/1/1/1.md
@@ -97,7 +97,7 @@ permalink: "{{ number | scNumberToPath }}/"
   width: 1px;
   height: 1px;
   overflow: hidden;
-  clip-path: polygon(0px 0px, 0px 0px, 0px 0px);
+  clip-path: polygon(1px 0, 1px 0, 1px 0, 1px 0);
   clip: rect(1px, 1px, 1px, 1px);
 }
 </style>

--- a/src/1/1/1.md
+++ b/src/1/1/1.md
@@ -82,7 +82,7 @@ permalink: "{{ number | scNumberToPath }}/"
 
 #### 良い実装例
 
-##### 不可視のテキスト要素を用意し、支援技術にはアイコン自体を無視させる方法
+##### 【推奨】 不可視のテキスト要素を用意し、支援技術にはアイコン自体を無視させる方法
 
 
 ```html
@@ -93,36 +93,44 @@ permalink: "{{ number | scNumberToPath }}/"
 
 <style>
 .visually-hidden {
-  visibility: hidden;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
 }
 </style>
 ```
 
-CSSで `visibility: hidden;` を使用する目的としては
+`.visually-hidden` クラスを使用する目的としては
 
 - 機械翻訳されやすい
 - 対応している支援技術が多い
 
-があるためできる限り、上記の実装を推奨とする。
+があるため、上記の実装を推奨とする。
+
+##### `visually-hidden` クラスの使用が難しい場合や実装上の都合でアイコン用のDOMにラベルの付与が難しい場合
+
+<details>
+  <summary>親要素にラベルを設定する方法</summary>
+
+  ```html
+  <button aria-label="閉じる">
+    <span aria-hidden="true"></span>
+  </button>
+  ```
+</details>
 
 
-##### 親要素にラベルを設定する方法
+<details>
+  <summary>roleをimgにした上で、ラベルを設定する方法</summary>
 
-`visually-hidden` クラスの使用が難しい場合や実装上の都合でアイコン用のDOMにラベルの付与が難しい場合など
-
-```html
-<button aria-label="閉じる">
-  <span aria-hidden="true"></span>
-</button>
-```
-
-##### roleをimgにした上で、ラベルを設定する方法
-
-```html
-<button>
-  <span role="img" aria-label="閉じる"></span>
-</button>
-```
+  ```html
+  <button>
+    <span role="img" aria-label="閉じる"></span>
+  </button>
+  ```
+</details>
 
 ### 意味のある画像を背景画像にしない
 

--- a/src/1/1/1.md
+++ b/src/1/1/1.md
@@ -97,7 +97,7 @@ permalink: "{{ number | scNumberToPath }}/"
   width: 1px;
   height: 1px;
   overflow: hidden;
-  clip-path: polygon(1px 0, 1px 0, 1px 0, 1px 0);
+  clip-path: inset(50%);
   clip: rect(1px, 1px, 1px, 1px);
 }
 </style>

--- a/src/1/1/1.md
+++ b/src/1/1/1.md
@@ -117,7 +117,7 @@ permalink: "{{ number | scNumberToPath }}/"
 
   ```html
   <button aria-label="閉じる">
-    <span aria-hidden="true"></span>
+    <span class="icon-close" aria-hidden="true"></span>
   </button>
   ```
 </details>
@@ -128,7 +128,7 @@ permalink: "{{ number | scNumberToPath }}/"
 
   ```html
   <button>
-    <span role="img" aria-label="閉じる"></span>
+    <span class="icon-close" role="img" aria-label="閉じる"></span>
   </button>
   ```
 </details>

--- a/src/1/1/1.md
+++ b/src/1/1/1.md
@@ -97,6 +97,7 @@ permalink: "{{ number | scNumberToPath }}/"
   width: 1px;
   height: 1px;
   overflow: hidden;
+  clip-path: polygon(0px 0px, 0px 0px, 0px 0px);
   clip: rect(1px, 1px, 1px, 1px);
 }
 </style>
@@ -109,7 +110,7 @@ permalink: "{{ number | scNumberToPath }}/"
 
 があるため、上記の実装を推奨とする。
 
-##### `visually-hidden` クラスの使用が難しい場合や実装上の都合でアイコン用のDOMにラベルの付与が難しい場合
+##### 実装上の都合で推奨例の実装が困難な場合
 
 <details>
   <summary>親要素にラベルを設定する方法</summary>

--- a/src/1/1/1.md
+++ b/src/1/1/1.md
@@ -82,21 +82,45 @@ permalink: "{{ number | scNumberToPath }}/"
 
 #### 良い実装例
 
-ラベルのないアイコンには、WAI-ARIAのaria-label属性を設定している
+##### 不可視のテキスト要素を用意し、支援技術にはアイコン自体を無視させる方法
 
-```html
-<i
-  class="icon icon-pen"
-  aria-label="ブログを書く">
-</i>
-```
-
-※アイコンにラベルが添えられている場合に `aria-label` 属性を設定すると、支援技術に二重で読み上げられてしまうことがあるため、次のように、`aria-hidden` 属性を設定する
 
 ```html
 <button>
-  <i class="icon icon-pen" aria-hidden="true"></i>
-  ブログを書く
+  <span class="icon-close" aria-hidden="true"></span>
+  <span class="visually-hidden">閉じる</span>
+</button>
+
+<style>
+.visually-hidden {
+  visibility: hidden;
+}
+</style>
+```
+
+CSSで `visibility: hidden;` を使用する目的としては
+
+- 機械翻訳されやすい
+- 対応している支援技術が多い
+
+があるためできる限り、上記の実装を推奨とする。
+
+
+##### 親要素にラベルを設定する方法
+
+`visually-hidden` クラスの使用が難しい場合や実装上の都合でアイコン用のDOMにラベルの付与が難しい場合など
+
+```html
+<button aria-label="閉じる">
+  <span aria-hidden="true"></span>
+</button>
+```
+
+##### roleをimgにした上で、ラベルを設定する方法
+
+```html
+<button>
+  <span role="img" aria-label="閉じる"></span>
 </button>
 ```
 

--- a/src/styles/detail/details.css
+++ b/src/styles/detail/details.css
@@ -8,6 +8,10 @@ details {
   border-radius: 4px;
 }
 
+details + details {
+  margin-top: 16px;
+}
+
 summary {
   text-indent: -1em;
   cursor: pointer;


### PR DESCRIPTION
### 概要
[1.1.1 アイコンの実装例の再考](https://github.com/openameba/a11y-guidelines/issues/56)
の文脈から再考してみました。

issueにある言い回しからは少し変えている部分もあります。

> ただしWebに限った話であること、長くなりすぎることから、推奨例以外はaccordionなどで隠しても良いかもと思っています。

あたりがポイントでしょうか。
場合によって

- roleをimgにした上で、ラベルを設定する方法
- 親要素にラベルを設定する方法

あたりは隠してしまってもいいかもしれません。
その辺りご意見いただければ幸いです。

### 変更後のスクリーンショット
![1 1 1](https://user-images.githubusercontent.com/14571646/114840103-6e792d80-9e11-11eb-8e85-5801c0d72d22.jpg)

## チェック項目
- [x] Pull Request の概要を適切に書いた
- [x] レビュアの指定をしている
- [x] textlintを実行しエラーが出ていない
