### PR TITLE
chore: add color-scheme for dark theme

### DIFF
--- a/src/_includes/partials/meta.html
+++ b/src/_includes/partials/meta.html
@@ -50,6 +50,8 @@
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:site" content="@ameba_official">
 
+<meta name="color-scheme" content="light dark">
+
 <link rel="canonical" href="{{ .Permalink }}">
 <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ .Site.BaseURL }}/img/apple-touch-icon.png">
 <link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{ .Site.BaseURL }}/img/apple-touch-icon.png">

--- a/src/_includes/partials/meta.njk
+++ b/src/_includes/partials/meta.njk
@@ -49,6 +49,8 @@
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:site" content="@ameba_official">
 
+<meta name="color-scheme" content="light dark">
+
 <link rel="canonical" href="{{ permalink }}">
 <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.baseURL }}/img/apple-touch-icon.png">
 <link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{ site.baseURL }}/img/apple-touch-icon.png">


### PR DESCRIPTION
## チェック項目

Pull Request を出す前に確認しましょう

- [x] Pull Request の概要を適切に書いた
- [x] レビュアの指定をしている
- [x] textlintを実行しエラーが出ていない

---

## 概要

すっかり入れ忘れていた `color-scheme` の指定を入れました。
参考: https://webkit.org/blog/8840/dark-mode-support-in-webkit/

現状表示されている要素だとおそらくほぼ影響はないと思われますが、今後のためにも入れておきたいと思いますです。


