### PR TITLE
参考リンクをWCAG2.1に修正

### DIFF
--- a/src/1/3/4.md
+++ b/src/1/3/4.md
@@ -57,4 +57,4 @@ permalink: "{{ number | scNumberToPath }}/"
 
 ## 参考文献
 
-- [Understanding Success Criterion 1.3.4: Orientation](https://www.w3.org/WAI/WCAG21/Understanding/orientation.html)
+- [達成基準 1.3.4: 表示の向きを理解する](https://waic.jp/docs/WCAG21/Understanding/orientation.html)

--- a/src/1/3/5.md
+++ b/src/1/3/5.md
@@ -64,7 +64,7 @@ permalink: "{{ number | scNumberToPath }}/"
 
 ## 参考文献
 
-- [Understanding Success Criterion 1.3.5: Identify Input Purpose](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html)
+- [達成基準 1.3.5: 入力目的の特定を理解する](https://waic.jp/docs/WCAG21/Understanding/identify-input-purpose.html)
 - [入力項目に適切なラベルと名前を付ける - 最適なフォームの作成  |  Web  |  Google Developers](https://developers.google.com/web/fundamentals/design-and-ux/input/forms/#_7)
 - [autocomplete - 入力欄 (フォーム入力) 要素 - HTML: HyperText Markup Language | MDN](https://developer.mozilla.org/ja/docs/Web/HTML/Element/Input#autocomplete)
 - [4.10.18.7 Autofill - HTML Living Standard](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill)

--- a/src/1/4/10.md
+++ b/src/1/4/10.md
@@ -46,4 +46,4 @@ permalink: "{{ number | scNumberToPath }}/"
 
 ## 参考文献
 
-- [Understanding Success Criterion 1.4.10 | Understanding WCAG 2.0](https://www.w3.org/WAI/WCAG21/Understanding/reflow.html)
+- [達成基準 1.4.10: リフローを理解する](https://waic.jp/docs/WCAG21/Understanding/reflow.html)

--- a/src/1/4/13.md
+++ b/src/1/4/13.md
@@ -56,4 +56,4 @@ permalink: "{{ number | scNumberToPath }}/"
 
 ## 参考文献
 
-- [Understanding Success Criterion 1.4.13：Content on Hover or Focus](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html)
+- [達成基準 1.4.13: ホバー又はフォーカスで表示されるコンテンツを理解する](https://waic.jp/docs/WCAG21/Understanding/content-on-hover-or-focus.html)

--- a/src/2/1/4.md
+++ b/src/2/1/4.md
@@ -28,4 +28,4 @@ permalink: "{{ number | scNumberToPath }}/"
 
 ## 参考文献
 
-- [Understanding Success Criterion 2.1.4：Character Key Shortcuts](https://www.w3.org/WAI/WCAG21/Understanding/character-key-shortcuts.html)
+- [達成基準 2.1.4: 文字キーのショートカットを理解する](https://waic.jp/docs/WCAG21/Understanding/character-key-shortcuts.html)

--- a/src/2/5/1.md
+++ b/src/2/5/1.md
@@ -21,4 +21,4 @@ permalink: "{{ number | scNumberToPath }}/"
 
 ## 参考文献
 
-- WCAG 2.1対応項目：原文 [Guideline 2.5.1 Pointer Gestures](https://www.w3.org/WAI/WCAG21/Understanding/pointer-gestures.html)
+- [達成基準 2.5.1: ポインタのジェスチャを理解する](https://waic.jp/docs/WCAG21/Understanding/pointer-gestures.html)

--- a/src/2/5/2.md
+++ b/src/2/5/2.md
@@ -28,4 +28,4 @@ permalink: "{{ number | scNumberToPath }}/"
 
 ## 参考文献
 
-- WCAG 2.1対応項目：原文 [Guideline 2.5.2 Pointer Cancellation](https://www.w3.org/WAI/WCAG21/Understanding/pointer-cancellation.html)
+- [達成基準 2.5.2: ポインタのキャンセルを理解する](https://waic.jp/docs/WCAG21/Understanding/pointer-cancellation.html)

--- a/src/2/5/3.md
+++ b/src/2/5/3.md
@@ -40,5 +40,5 @@ aria-labelで表示されたテキストは「Find in this site」だが、視�
 
 
 ## 参考文献
-- [Understanding Success Criterion 2.5.3: Status Messages](https://www.w3.org/WAI/WCAG21/Understanding/label-in-name)
+- [達成基準 2.5.3: 名前 (name) のラベルを理解する](https://waic.jp/docs/WCAG21/Understanding/label-in-name.html)
 - [Failure due to "accessible name" not containing the visible label text](https://www.w3.org/WAI/WCAG21/Techniques/failures/F96)

--- a/src/2/5/4.md
+++ b/src/2/5/4.md
@@ -21,4 +21,4 @@ permalink: "{{ number | scNumberToPath }}/"
 -  動きによる操作以外の方法で操作する機能がある
 
 ## 参考文献
-- [Understanding Success Criterion 2.5.4: Motion Actuation](https://www.w3.org/WAI/WCAG21/Understanding/motion-actuation)
+- [達成基準 2.5.4: 動きによる起動を理解する](https://waic.jp/docs/WCAG21/Understanding/motion-actuation.html)

--- a/src/2/5/5.md
+++ b/src/2/5/5.md
@@ -45,5 +45,4 @@ permalink: "{{ number | scNumberToPath }}/"
 - マークアップ実装時、コードレビューによるチェック
 
 ## 参考文献
-- WCAG 2.1対応項目：原文 [Guideline 2.5.5 Target Size](https://www.w3.org/WAI/WCAG21/Understanding/target-size)
-- [達成基準 2.5.5: ターゲットのサイズを理解する | WCAG 2.0解説書](https://waic.jp/docs/WCAG21/Understanding/target-size.html)
+- [達成基準 2.5.5: ターゲットのサイズを理解する](https://waic.jp/docs/WCAG21/Understanding/target-size.html)

--- a/src/4/1/3.md
+++ b/src/4/1/3.md
@@ -61,5 +61,5 @@ role属性をサポートしていないブラウザがあるので、WAI-ARIA�
 
 
 ## 参考文献
-- [Understanding Success Criterion 4.1.3: Status Messages](https://www.w3.org/WAI/WCAG21/Understanding/status-messages.html)
+- [達成基準 4.1.3: ステータスメッセージを理解する](https://waic.jp/docs/WCAG21/Understanding/status-messages.html)
 - [ARIA19: エラーを特定するために、ARIA role=alert 又はライブリージョン (Live Regions) を使用する](https://waic.jp/docs/WCAG-TECHS/ARIA19.html)


### PR DESCRIPTION
## 概要
各ページにある参考リンクをWCAG2.1のものに差し替えました。
リンク先や文言などにミスがないかレビューをお願いできればと思います。

## 関連するissue
https://github.com/openameba/a11y-guidelines/issues/64

## チェック項目
- [x] Pull Request の概要を適切に書いた
- [x] レビュアの指定をしている
- [x] textlintを実行しエラーが出ていない
