### PR TITLE
theme切り替えのSwitchをもっとクリッカブルに

### DIFF
--- a/src/_includes/partials/script.njk
+++ b/src/_includes/partials/script.njk
@@ -213,6 +213,16 @@ export class SpindleThemeSwitch extends HTMLElement {
           background-image: url('data:image/svg+xml;utf8, <svg fill="%23de4d14" width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M16.5 12c0 2.48-2.02 4.5-4.5 4.5S7.5 14.48 7.5 12 9.52 7.5 12 7.5s4.5 2.02 4.5 4.5zM12 5.5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1s-1 .45-1 1v1.5c0 .55.45 1 1 1zm0 13c-.55 0-1 .45-1 1V21c0 .55.45 1 1 1s1-.45 1-1v-1.5c0-.55-.45-1-1-1zm5.3-10.8c.26 0 .51-.1.71-.29l1.06-1.06a.996.996 0 1 0-1.41-1.41L16.6 5.99a.996.996 0 0 0 0 1.41c.19.2.45.3.7.3zM5.99 16.6l-1.06 1.06a.996.996 0 0 0 .71 1.7c.26 0 .51-.1.71-.29l1.06-1.06a.996.996 0 0 0 0-1.41c-.39-.39-1.03-.39-1.42 0zM21 11h-1.5c-.55 0-1 .45-1 1s.45 1 1 1H21c.55 0 1-.45 1-1s-.45-1-1-1zM5.5 12c0-.55-.45-1-1-1H3c-.55 0-1 .45-1 1s.45 1 1 1h1.5c.55 0 1-.45 1-1zm12.51 4.6a.996.996 0 1 0-1.41 1.41l1.06 1.06c.2.2.45.29.71.29.26 0 .51-.1.71-.29a.996.996 0 0 0 0-1.41l-1.07-1.06zM5.99 7.4c.19.2.45.3.71.3.26 0 .51-.1.7-.3a.996.996 0 0 0 0-1.41L6.34 4.93a.996.996 0 1 0-1.41 1.41L5.99 7.4z"/></svg>');
         }
 
+        .theme:not(:checked) + .switch-label::before {
+          content: "";
+          position: absolute;
+          top: 0;
+          left: 0;
+          bottom: 0;
+          right: 0;
+          z-index: 2;
+        }
+
         .label {
           color: var(--color-text-medium-emphasis);
           font-size: calc(12 / 16 * 1rem);
@@ -231,10 +241,10 @@ export class SpindleThemeSwitch extends HTMLElement {
         <fieldset>
           <legend class="visually-hidden">${label}</legend>
           <div class="switch">
-            <label class="visually-hidden" for="spindle-theme-switch-dark">ダークテーマ</label>
             <input class="theme theme-dark" id="spindle-theme-switch-dark" name="theme" type="radio" value="${DARK}">
-            <label class="visually-hidden" for="spindle-theme-switch-light">ライトテーマ</label>
+            <label class="switch-label" for="spindle-theme-switch-dark"><span class="visually-hidden">ダークテーマ</span></label>
             <input class="theme theme-light" id="spindle-theme-switch-light" name="theme" type="radio" value="${LIGHT}">
+            <label class="switch-label" for="spindle-theme-switch-light"><span class="visually-hidden">ライトテーマ</span></label>
             <span class="switch-theme-background"></span>
           </div>
         </fieldset>


### PR DESCRIPTION
## 概要

ライトとダークのテーマ切り替えのSwitch UIのクリック可能なエリアが小さいため、Switch全体をクリッカブルにしました。

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/445333/139039556-56967331-52bc-42b2-988e-a356ad25d07e.gif) | ![after](https://user-images.githubusercontent.com/445333/139039571-28ce742a-6ff0-47d5-ba9e-22b703a9c4b9.gif) |
 