### PR TITLE
項目1.1.1にアプリの実装方法を追加

### DIFF
--- a/src/1/1/1.md
+++ b/src/1/1/1.md
@@ -48,9 +48,11 @@ permalink: "{{ number | scNumberToPath }}/"
 
 ## 実装方法
 
-### `<img>` 要素の `alt` 属性に、画像を説明するテキストを設定する
+### Web
 
-#### 悪い実装例
+#### `<img>` 要素の `alt` 属性に、画像を説明するテキストを設定する
+
+##### 悪い実装例
 
 `<img>` 要素に `alt` 属性がない
 
@@ -62,7 +64,7 @@ permalink: "{{ number | scNumberToPath }}/"
 - 特に、リンク要素の中にこういった画像があると、ユーザーはクリックで何が起きるかが想定できない
 - 代替テキストが不要で装飾的な画像の場合には、空の `alt` 属性を設定する
 
-#### 良い実装例
+##### 良い実装例
 
 `<img>` 要素の `alt` 属性に、画像を説明するテキストを設定する
 
@@ -70,9 +72,9 @@ permalink: "{{ number | scNumberToPath }}/"
 <img src="ameblo.png" alt="アメブロ" width="100" height="50">
 ```
 
-### ラベルのないアイコンに、代替テキストを設定する
+#### ラベルのないアイコンに、代替テキストを設定する
 
-#### 悪い実装例
+##### 悪い実装例
 
 ラベルや代替テキストがないアイコンの場合、アイコンの意味が理解できない
 
@@ -80,9 +82,9 @@ permalink: "{{ number | scNumberToPath }}/"
 <i class="icon icon-pen"></i>
 ```
 
-#### 良い実装例
+##### 良い実装例
 
-##### 【推奨】 不可視のテキスト要素を用意し、支援技術にはアイコン自体を無視させる方法
+###### 【推奨】 不可視のテキスト要素を用意し、支援技術にはアイコン自体を無視させる方法
 
 
 ```html
@@ -110,7 +112,7 @@ permalink: "{{ number | scNumberToPath }}/"
 
 があるため、上記の実装を推奨とする。
 
-##### 実装上の都合で推奨例の実装が困難な場合
+###### 実装上の都合で推奨例の実装が困難な場合
 
 <details>
   <summary>親要素にラベルを設定する方法</summary>
@@ -133,9 +135,9 @@ permalink: "{{ number | scNumberToPath }}/"
   ```
 </details>
 
-### 意味のある画像を背景画像にしない
+#### 意味のある画像を背景画像にしない
 
-#### 悪い実装例
+##### 悪い実装例
 
 ```html
 <div style="background-image: url(ameblo.png)"></div>
@@ -144,13 +146,13 @@ permalink: "{{ number | scNumberToPath }}/"
 - 印刷時に背景画像は表示されないことがある（ブラウザの初期設定では、背景画像は印刷しない）
 - ハイコントラストモードで、背景画像は表示されなくなることもある
 
-#### 良い実装例
+##### 良い実装例
 
 ```html
 <img src="ameblo.png" alt="アメブロ" width="100" height="50">
 ```
 
-#### 困ったとき
+##### 困ったとき
 
 WAI-ARIAの `aria-label` 属性、`role` 属性を設定する
 
@@ -161,6 +163,23 @@ WAI-ARIAの `aria-label` 属性、`role` 属性を設定する
   role="img">
 </div>
 ```
+
+### Android
+
+#### contentDescription属性に読み上げテキストを設定する
+
+```
+<ImageView android:contentDescription="hoge" />
+```
+
+### iOS
+
+#### accessibilityLabelプロパティに読み上げテキストを設定する
+
+```
+imageView.accessibilityLabel = "hoge"
+```
+
 
 ## 参考文献
 


### PR DESCRIPTION
### 概要
**1.1.1 画像に代替テキストを提供する** にアプリの実装方法を追加しました。

その影響で

- Web
- Android
- iOS

という見出しを追加し、それに紐づく見出したちは見出しレベルを1つさげています。
その影響で h6 を使用するケースが出てきたのですが文字少し小さい気もしています。

### チェック項目

Pull Request を出す前に確認しましょう
- [x] Pull Request の概要を適切に書いた
- [x] レビュアの指定をしている
- [x] textlintを実行しエラーが出ていない

### スクリーンショット
<img width="196" alt="スクリーンショット 2021-12-21 17 34 50" src="https://user-images.githubusercontent.com/14571646/146898705-a3af55e1-5eaa-4bf7-a34e-dbf7ec330cf9.png">

一応、修正後のスクリーンショットを載せておきます。長めです。

