### PR TITLE
ページ内リンクでの遷移時に上部に余白をあける

### DIFF
--- a/src/styles/common/base.css
+++ b/src/styles/common/base.css
@@ -6,6 +6,7 @@ html {
   font-family: Meiryo, 'Yu Gothic Medium', system-ui, -apple-system,
     BlinkMacSystemFont, sans-serif;
   line-height: 1.5;
+  scroll-padding-top: 1.5em;
 }
 
 body {


### PR DESCRIPTION
## 概要

#271 の続き。

- `scroll-padding-top` でページ内スクロール時に余白をつくる
