### PR TITLE
見出しに対してfont-sizeの指定を追加

### DIFF
--- a/src/styles/default/heading.css
+++ b/src/styles/default/heading.css
@@ -40,3 +40,9 @@ h5 {
   margin: 32px 0 24px;
   padding-left: 16px;
 }
+
+h6 {
+  font-size: calc(14 / 16 * 1rem);
+  line-height: 1.71;
+  margin: 24px 0 16px;
+}

--- a/src/styles/detail/heading.css
+++ b/src/styles/detail/heading.css
@@ -34,3 +34,11 @@ h4 {
   margin: 32px 0 24px;
   padding-left: 16px;
 }
+
+h5 {
+  font-size: calc(14 / 16 * 1rem);
+}
+
+h6 {
+  font-size: calc(12 / 16 * 1rem);
+}

--- a/src/styles/detail/heading.css
+++ b/src/styles/detail/heading.css
@@ -37,8 +37,12 @@ h4 {
 
 h5 {
   font-size: calc(14 / 16 * 1rem);
+  line-height: 1.71;
+  margin: 24px 0 16px;
 }
 
 h6 {
   font-size: calc(12 / 16 * 1rem);
+  line-height: 1.71;
+  margin: 16px 0 8px;
 }


### PR DESCRIPTION
### 概要
項目1.1.1などでh5やh6の見出しが使われているのですがサイズが少し小さく見づらいというご意見があり `font-size` の指定を追加してみました。

必要最低限として `font-size` のみ追加していますが

- `h4` などと同様にline-heightやmargin指定も追加するべきか
- default.cssで使用している[heading指定](https://github.com/openameba/a11y-guidelines/blob/master/src/styles/default/heading.css)へもh6の記述追加するべきか

あたり迷ったのでもし最適解ありましたらコメントいただければと思います。

### スクリーンショット

#### Before
<img width="724" alt="before" src="https://user-images.githubusercontent.com/14571646/148186289-c01c3c3c-a0e0-4d9f-8943-cecc402d0139.png">

#### After
<img width="721" alt="after" src="https://user-images.githubusercontent.com/14571646/148186327-037f8179-916e-4578-ab8c-7cd1850f2369.png">

修正したことにより文字サイズ12px相当になりました。

### チェック項目
- [x] Pull Request の概要を適切に書いた
- [x] レビュアの指定をしている
- [x] textlintを実行しエラーが出ていない