### PR TITLE
参考文献にある404リンクを差し替え

### DIFF
--- a/src/2/3/3.md
+++ b/src/2/3/3.md
@@ -62,5 +62,5 @@ permalink: "{{ number | scNumberToPath }}/"
 ## 参考文献
 
 - [達成基準 2.3.3: インタラクションによるアニメーションを理解する](https://waic.jp/docs/WCAG21/Understanding/animation-from-interactions.html)
-- [UIデザインへのアプローチ Part 2: インタラクションとアニメーション（UXデザイン入門シリーズ）| アドビUX道場 #UXDojo](https://blogs.adobe.com/japan/web-fundamentals-ui-design-part-2-interactions-animations/)
+- [UIデザインへのアプローチ Part 2: インタラクションとアニメーション（UXデザイン入門シリーズ）| アドビUX道場 #UXDojo](https://blog.adobe.com/jp/publish/2018/11/12/web-fundamentals-ui-design-part-2-interactions-animations)
 - [prefers-reduced-motion - CSS: カスケーディングスタイルシート | MDN](https://developer.mozilla.org/ja/docs/Web/CSS/@media/prefers-reduced-motion)


### PR DESCRIPTION
### 概要
参考文献のリンクが404だったので修正しました。
新しく設定したリンク先のタイトルは変わってなかったのでURLのみ差し替えています。
issueにあったURLのハッシュなくても問題なく遷移していそうだっためハッシュはつけておりません。

### 関連するissue
fix https://github.com/openameba/a11y-guidelines/issues/288

### チェック項目
- [x] Pull Request の概要を適切に書いた
- [x] レビュアの指定をしている
- [x] textlintを実行しエラーが出ていない

