### PR TITLE
達成方法集のリンクをWCAG2.1に修正

### DIFF
--- a/src/1/3/2.md
+++ b/src/1/3/2.md
@@ -77,4 +77,4 @@ textLabel.attributedText = attrString
 - [達成基準 1.3.2: 意味のある順序を理解する](https://waic.jp/docs/WCAG21/Understanding/meaningful-sequence.html)
 - [C27: DOM の順序を表示順序と一致させる | WCAG 2.1 達成方法集](https://waic.jp/docs/WCAG21/Techniques/css/C27)
 - [C8: 単語内の文字間隔を制御するために、CSSのletter-spacingを使用する | WCAG 2.1 達成方法集](https://waic.jp/docs/WCAG21/Techniques/css/C8)
-- [F32: 達成基準 1.3.2 の失敗例 － 単語内の間隔を制御するために、空白文字を使用している | WCAG 2.0 達成方法集](https://waic.jp/docs/WCAG-TECHS/F32)
+- [F32: 達成基準 1.3.2 の失敗例 － 単語内の間隔を制御するために、空白文字を使用している | WCAG 2.1 達成方法集](https://waic.jp/docs/WCAG21/Techniques/failures/F32)

--- a/src/1/3/3.md
+++ b/src/1/3/3.md
@@ -80,4 +80,4 @@ permalink: "{{ number | scNumberToPath }}/"
 
 - [達成基準 1.3.3: 感覚的な特徴を理解する](https://waic.jp/docs/WCAG21/Understanding/sensory-characteristics.html)
 - [G96: 理解させる必要のあるアイテムを感覚的にだけ伝えるのではなく、テキストによる識別情報もあわせて提供する | WCAG 2.1 達成方法集](https://waic.jp/docs/WCAG21/Techniques/general/G96)
-- [F14: 達成基準 1.3.3 の失敗例 － 形状又は位置のみでコンテンツを特定している | WCAG 2.0 達成方法集](https://waic.jp/docs/WCAG-TECHS/F14)
+- [F14: 達成基準 1.3.3 の失敗例 － 形状又は位置のみでコンテンツを特定している | WCAG 2.1 達成方法集](https://waic.jp/docs/WCAG21/Techniques/failures/F14)

--- a/src/2/1/2.md
+++ b/src/2/1/2.md
@@ -117,5 +117,5 @@ override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
 ## 参考文献
 
 - [達成基準 2.1.2: キーボードトラップなしを理解する](https://waic.jp/docs/WCAG21/Understanding/no-keyboard-trap.html)
-- [F10: 達成基準 2.1.2 及び 適合要件 5 の失敗例 － 利用者を一つのフォーマット型の中に閉じ込める方法で、複数のコンテンツフォーマットを組み合わせている | WCAG 2.0 達成方法集](http://waic.jp/docs/WCAG-TECHS/F10)
+- [F10: 達成基準 2.1.2 及び 適合要件 5 の失敗例 － 利用者を一つのフォーマット型の中に閉じ込める方法で、複数のコンテンツフォーマットを組み合わせている | WCAG 2.1 達成方法集](https://waic.jp/docs/WCAG21/Techniques/failures/F10)
 - [キーボード アクションの処理 | Android Developers](https://developer.android.com/training/keyboard-input/commands?hl=ja)

--- a/src/2/2/4.md
+++ b/src/2/2/4.md
@@ -59,4 +59,4 @@ metaタグのhttp-equiv属性を利用した、一定時間後に自動的に更
 ## 参考文献
 
 - [達成基準 2.2.4: 割り込みを理解する](https://waic.jp/docs/WCAG21/Understanding/interruptions.html)
-- [F40: 達成基準 2.2.1 及び 達成基準 2.2.4 の失敗例 － 制限時間付きの meta 要素リダイレクトを使用している | WCAG 2.0 達成方法集](https://waic.jp/docs/WCAG-TECHS/F40)
+- [F40: 達成基準 2.2.1、達成基準 2.2.4、及び 達成基準 3.2.5 の失敗例 － 制限時間付きの meta 要素リダイレクトを使用している | WCAG 2.1 達成方法集](https://waic.jp/docs/WCAG21/Techniques/failures/F40)

--- a/src/4/1/2.md
+++ b/src/4/1/2.md
@@ -65,4 +65,4 @@ buttonタグを使って実装している
 
 - [達成基準 4.1.2: 名前 (name)・役割 (role) 及び値 (value) を理解する](https://waic.jp/docs/WCAG21/Understanding/name-role-value.html)
 - [ARIA4: ユーザインターフェース コンポーネントの役割 (role) を明示するために、WAI-ARIA ロールを使用する | WCAG 2.1 達成方法集](https://waic.jp/docs/WCAG21/Techniques/aria/ARIA4)
-- [F59: 達成基準 4.1.2 の失敗例 － コントロールに役割 (role) を提供せずに、HTMLのdiv要素又はspan要素をユーザインタフェースコントロールするためにスクリプトを用いている | WCAG 2.0 達成方法集](https://waic.jp/docs/WCAG-TECHS/F59)
+- [F59: 達成基準 4.1.2 の失敗例 － コントロールに役割 (role) を提供せずに、HTML の div 要素又は span 要素をユーザインタフェースコントロールにするために、スクリプトを用いている | WCAG 2.1 達成方法集](https://waic.jp/docs/WCAG21/Techniques/failures/F59)


### PR DESCRIPTION
### 概要
表題の通り、WCAG2.0へのリンクを2.1に変更しました。

[以前](https://github.com/openameba/a11y-guidelines/pull/252)も差し替えをおこないましたが翻訳されていた箇所増えてたので追加で修正をしました。

### 今回変更した箇所
### 対象
https://github.com/openameba/a11y-guidelines/blob/master/src/1/3/2.md
想定されるWCAG2.1へのリンク（[F32](https://waic.jp/docs/WCAG21/Techniques/failures/F32)）

https://github.com/openameba/a11y-guidelines/blob/master/src/1/3/3.md
想定されるWCAG2.1へのリンク（[F14](https://waic.jp/docs/WCAG21/Techniques/failures/F14)）

https://github.com/openameba/a11y-guidelines/blob/master/src/2/1/2.md
想定されるWCAG2.1へのリンク（[F10](https://waic.jp/docs/WCAG21/Techniques/failures/F10)）

https://github.com/openameba/a11y-guidelines/blob/master/src/2/2/4.md
想定されるWCAG2.1へのリンク（[F40](https://waic.jp/docs/WCAG21/Techniques/failures/F40)）

https://github.com/openameba/a11y-guidelines/blob/master/src/4/1/2.md
想定されるWCAG2.1へのリンク（[F59](https://waic.jp/docs/WCAG21/Techniques/failures/F59)）

### 関連するissue
https://github.com/openameba/a11y-guidelines/issues/253

## チェック項目
- [x] Pull Request の概要を適切に書いた
- [x] レビュアの指定をしている
- [x] textlintを実行しエラーが出ていない
