### PR TITLE
各項目の参考リンクがWCAG2.0解説書なので2.1に差し替える

### DIFF
--- a/src/1/4/4.md
+++ b/src/1/4/4.md
@@ -105,4 +105,4 @@ maximum-scale=1.0、user-scalable=noが設定されているため、ダブル�
 
 - [達成基準 1.4.4: テキストのサイズ変更を理解する](https://waic.jp/docs/WCAG21/Understanding/resize-text.html)
 - [C14: フォントサイズに em 単位を使用する | WCAG 2.1 達成方法集](https://waic.jp/docs/WCAG21/Techniques/css/C14)
-- [G179: 文字サイズを変更し、かつテキストコンテナの幅を変更しないときに、コンテンツ又は機能が損なわれないようにする | WCAG 2.0 達成方法集](https://waic.jp/docs/WCAG-TECHS/G179)
+- [G179: 文字サイズを変更し、かつテキストコンテナの幅を変更しないときに、コンテンツ又は機能が損なわれないようにする | WCAG 2.1 達成方法集](https://waic.jp/docs/WCAG21/Techniques/general/G179)

--- a/src/3/2/1.md
+++ b/src/3/2/1.md
@@ -33,4 +33,4 @@ permalink: "{{ number | scNumberToPath }}/"
 ## 参考文献
 
 - [達成基準 3.2.1: フォーカス時を理解する](https://waic.jp/docs/WCAG21/Understanding/on-focus.html)
-- [G201: 新しいウィンドウを開くときに、利用者へ事前に知らせる | WCAG 2.0 達成方法集](https://waic.jp/docs/WCAG-TECHS/G201)
+- [G201: 新しいウィンドウを開くときに、利用者へ事前に知らせる | WCAG 2.1 達成方法集](https://waic.jp/docs/WCAG21/Techniques/general/G201)


### PR DESCRIPTION
## 概要
[こちらのIssue](https://github.com/openameba/a11y-guidelines/issues/253)の対応になります。
WCAG2.0解説書にリンクしていた項目を2.1に変更しました。

## チェック項目

Pull Request を出す前に確認しましょう

- [x] Pull Request の概要を適切に書いた
- [x] レビュアの指定をしている
- [x] textlintを実行しエラーが出ていない

## スクリーンショット

| G179のリンク修正 | G201のリンク修正 |
|:---:|:---:|
| ![1 4 4](https://user-images.githubusercontent.com/3806115/172542976-70c066a3-02f0-45ea-ae46-cd33b95c40ba.gif) | ![3 2 1](https://user-images.githubusercontent.com/3806115/172543050-dec0c798-ac79-44bf-a11d-d2cc58ae35a0.gif) |
