### PR TITLE
`2.4.7`の良い実装例の記述を修正

### DIFF
--- a/src/2/4/7.md
+++ b/src/2/4/7.md
@@ -71,7 +71,7 @@ permalink: "{{ number | scNumberToPath }}/"
   }
   .button2:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 2px #fff, 0 0 0 4px #2d8c3c;
+    box-shadow: 0 0 0 2px #fff, 0 0 0 4px #0091ff;
   }
 </style>
 

--- a/src/2/4/7.md
+++ b/src/2/4/7.md
@@ -66,10 +66,10 @@ permalink: "{{ number | scNumberToPath }}/"
 
 ```html
 <style>
-  .button1 {
+  .button1:focus-visible {
     outline: 1;
   }
-  .button2 {
+  .button2:focus-visible {
     outline: none;
     box-shadow: 0 0 0 2px #fff, 0 0 0 4px #2d8c3c;
   }


### PR DESCRIPTION
## チェック項目

Pull Request を出す前に確認しましょう

- [x] Pull Request の概要を適切に書いた
- [x] レビュアの指定をしている
- [x] textlintを実行しエラーが出ていない

---

## 概要
[2.4.7 良い実装例](https://a11y-guidelines.ameba.design/2/4/7/#%E8%89%AF%E3%81%84%E5%AE%9F%E8%A3%85%E4%BE%8B)の記述を修正しました 🚀 

2.4.7の実装例としては「フォーカス時の」実装例が載っているべきでしたが、実際は「通常時の」スタイルが載っており、このコードのまま実装すると常にフォーカスが表示されてしまっています

実装例のコードのまま実装した結果👇
<img width="505" alt="スクリーンショット 2022-06-14 15 22 51" src="https://user-images.githubusercontent.com/42470015/173507528-72d9d6e1-5776-4dae-8b5d-fa288473e61b.png">

そのため、実装例に`:focus-visible`を追加しました

## Issue
fix https://github.com/openameba/a11y-guidelines/issues/333
