### PR TITLE
達成基準3.3.2の図の位置を`実装方法`から`概要`に移動

### DIFF
--- a/src/3/3/2.md
+++ b/src/3/3/2.md
@@ -18,10 +18,6 @@ permalink: "{{ number | scNumberToPath }}/"
 クリック範囲や紐付けなどは、適切なマークアップを行い、長文の場合は常に表示させなくても良い。ユーザーが入力をしようとフォーカスした時に読み上げられることが重要。
 ただし、placeholderをラベル代わりに使うと、入力中に分からなくなるため避ける。
 
-## 実装方法
-
-### Web
-
 <ul class="Figurelist">
 <li>
 <figure>
@@ -45,6 +41,7 @@ placeholderをラベル代わりにしている。入力中にはラベルが表
 </li>
 </ul>
 
+## 実装方法
 ### Android
 
 - `TextInputEditText`を`TextInputLayout`で囲う


### PR DESCRIPTION
## 概要
達成基準3.3.2の図の位置を`実装方法`から`概要`に移動しました

| before | after |
| -- | -- |
| ![スクリーンショット 2022-07-10 22 08 02](https://user-images.githubusercontent.com/42470015/178146551-c7c4636b-145b-4dca-9a78-554129b99ccb.png) | ![スクリーンショット 2022-07-10 22 17 35](https://user-images.githubusercontent.com/42470015/178146557-d1b22940-e860-453d-a653-e02fd22d3271.png) |

上記の図はあくまで概要に記載されている内容の補足にあたるので、`概要`の中に移動させました
他の章同様、`実装方法`には具体的な実装例やコードが記載されている形に統一したいです！

## 関連リンク
<!-- 関連するIssueやPull Requestなど -->
https://a11y-guidelines.ameba.design/3/3/2/

## 確認項目
Pull Requestを出す前に確認しましょう。

- [x] コミットは適切にまとめられているか
- [x] Pull Requestの概要を適切に書いたか
- [x] レビュワーの指定をしているか
- [x] textlintを実行しエラーが出ていないか
- [ ] Accessibility
  - [ ] altは適切に設定したか([参考(1.1.1 画像に代替テキストを提供する)](https://openameba.github.io/a11y-guidelines/1/1/1/))

## その他
<!-- レビュワーへの申し送りやその他コメント等あれば -->
どこかのタイミングで3.3.2にもWebの実装方法を記載したいです