### PR TITLE
GitHub Actions から直接ウェブサイトをデプロイする

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -6,26 +6,31 @@ on:
       - master
 
 jobs:
-  build-deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: '16.x'
-
-      - name: Build Site
-        run: |
-          npm ci
-          npm run build
-
+      - run: npm ci
+      - run: npm run build
       - name: Create CNAME file to apply custom domain
         run: echo 'a11y-guidelines.ameba.design' > public/CNAME
-
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload artifacts
+        uses: actions/upload-pages-artifact@v1
         with:
-          forceOrphan: true
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./public
-          publish_branch: gh-pages
+          path: public
+  deploy:
+    needs:
+      - build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/deploy-pages@v1
+        id: deployment


### PR DESCRIPTION
## 概要

現在 `gh-pages` ブランチをプッシュしてウェブサイトを更新する方法をとっていますが、わざわざブランチを用意せずともデプロイすることが可能になりました：

[GitHub Pages: Custom GitHub Actions Workflows (beta) | GitHub Changelog](https://github.blog/changelog/2022-07-27-github-pages-custom-github-actions-workflows-beta/)

まだベータ版なので勇足かもしれませんが、 `gh-pages` ブランチがなくなるとスッキリすると思うので対応してみました。

## 関連リンク

<!-- 関連するIssueやPull Requestなど -->

- [GitHub Pages: Custom GitHub Actions Workflows (beta) | GitHub Changelog](https://github.blog/changelog/2022-07-27-github-pages-custom-github-actions-workflows-beta/)
- [GitHub Pages: Builds with GitHub Actions GA | GitHub Changelog](https://github.blog/changelog/2022-08-10-github-pages-builds-with-github-actions-ga/)
- [actions/deploy-pages](https://github.com/actions/deploy-pages)
- [actions/upload-pages-artifact: A composite action for packaging and uploading an artifact that can be deployed to GitHub Pages.](https://github.com/actions/upload-pages-artifact)

## 確認項目

Pull Requestを出す前に確認しましょう。

- [x] コミットは適切にまとめられているか
- [x] Pull Requestの概要を適切に書いたか
- [x] レビュワーの指定をしているか
- textlintを実行しエラーが出ていないか
- Accessibility
  - altは適切に設定したか([参考(1.1.1 画像に代替テキストを提供する)](https://openameba.github.io/a11y-guidelines/1/1/1/))

## その他

<!-- レビュワーへの申し送りやその他コメント等あれば -->

マージ前・マージ後どちらでも良いのですが以下の設定を変更する必要があります。

<img width="1197" alt="スクリーンショット 2022-10-24 10 54 52" src="https://user-images.githubusercontent.com/309466/197432948-4f5cde1c-36c6-4fd6-8693-04c1577e9a08.png">
<img width="325" alt="スクリーンショット 2022-10-24 10 55 16" src="https://user-images.githubusercontent.com/309466/197432952-36f9bab1-2f42-44dc-bb65-8fbdfe1b14d0.png">