### PR TITLE
VRTのキャッシュ対象ディレクトリをGITHUB_OUTPUTに変更

### DIFF
--- a/.github/workflows/visual-regression-test.yml
+++ b/.github/workflows/visual-regression-test.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           node-version: '16.x'
       - id: npm-cache-dir
-        run: echo "::set-output name=dir::$(npm config get cache)"
+        run: echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
       - id: npm-cache
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
## 概要
`set-output` でwarningが出ておりvisual regression testが動かなくなっていたものをGITHUB_OUTPUTへの書き込みに修正してみました。
このPull requestでvisual regression testが今まで通り動いていればOK。

## 関連リンク
[GitHub Actions: Deprecating save-state and set-output commands - The GitHub Blog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#examples)

## 確認項目
- [x] コミットは適切にまとめられているか
- [x] Pull Requestの概要を適切に書いたか
- [x] レビュワーの指定をしているか
- [x] textlintを実行しエラーが出ていないか
