### PR TITLE
達成基準2.1.1の内容を修正

### DIFF
--- a/src/2/1/1.md
+++ b/src/2/1/1.md
@@ -34,7 +34,7 @@ permalink: "{{ number | scNumberToPath }}/"
 
 #### 悪い実装例
 
-フォーカスを受け取れない要素を利用したコンテンツの出し分けなどをしている。
+フォーカスを受け取ることができない要素にクリックイベントを実装している。
 
 ```html
 <div onclick="...">
@@ -44,12 +44,22 @@ permalink: "{{ number | scNumberToPath }}/"
 
 #### 良い実装例
 
-フォーカスを受け取れる要素の使用、`tabindex` 属性の付与、`focus` 擬似クラスの併用などを行なっている。
+##### 【推奨】 フォーカスを受け取れる要素にクリックイベントを実装している
 
 ```html
-<button type="button" onclick="..." tabindex="1">
+<button type="button" onclick="...">
   content...
 </button>
+```
+
+##### 実装上の都合で推奨例の実装が困難な場合
+
+フォーカス可能な要素に変更できない場合、`tabindex`属性を付与してフォーカス可能にできる。ただしこの場合、別項[2.4.7 フォーカスを見えるようにする](/2/4/7/)にも留意する。
+
+```html
+<div onclick="..." tabindex="0">
+  content...
+</div>
 ```
 
 ### Android


### PR DESCRIPTION
## 概要
issueへの起票を受けまして達成基準2.1.1の内容を修正してみました。
一部、文章表現もうちょっとわかりやすくできそうだなと思いまして

### issueでの提案と実際の修正差異

> フォーカスを受け取れない要素にクリックイベントを実装している。

フォーカスを受け取ることができない要素にクリックイベントを実装している。

> 要素を変更できない場合などに、tabindex属性を付与してフォーカス可能にすることもできる。ただしこの場合、別項2.4.7 フォーカスを見えるようにするにも留意する。

フォーカス可能な要素に変更できない場合、tabindex属性を付与してフォーカス可能にできる。ただしこの場合、別項2.4.7 フォーカスを見えるようにするにも留意する。


## 関連するissue
https://github.com/openameba/a11y-guidelines/issues/258

## 確認項目
- [x] コミットは適切にまとめられているか
- [x] Pull Requestの概要を適切に書いたか
- [x] レビュワーの指定をしているか
- [x] textlintを実行しエラーが出ていないか