### PR TITLE
fix: npm9でコミットできない

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run lint-staged
+npx lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-"$(npm bin)"/lint-staged
+npm run lint-staged

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "format:prettier": "prettier --write {src,npm_scripts,.eleventy.js,package.json}",
     "format:text": "textlint --fix content src",
     "lint": "run-p lint:*",
-    "lint-staged": "lint-staged",
     "lint:prettier": "prettier -c {src,npm_scripts,.eleventy.js,package.json}",
     "lint:text": "textlint content src",
     "prepare": "[ -n \"$CI\" ] || husky install",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "format:prettier": "prettier --write {src,npm_scripts,.eleventy.js,package.json}",
     "format:text": "textlint --fix content src",
     "lint": "run-p lint:*",
+    "lint-staged": "lint-staged",
     "lint:prettier": "prettier -c {src,npm_scripts,.eleventy.js,package.json}",
     "lint:text": "textlint content src",
     "prepare": "[ -n \"$CI\" ] || husky install",


### PR DESCRIPTION
## 概要

[npm 9で `npm bin` が廃止になり](https://github.com/npm/cli/blob/v9.8.1/CHANGELOG.md#-breaking-changes)、localでlint-stagedの実行に失敗してコミットできなくなっていたので修正しました。
node 18に上がってからも他の人コミットしていそうだしターミナルでやるとダメとかあるんでしょうか 🤔 

## 確認方法

1. npm 9以上（node 18ならなると思うが・・）でmasterブランチをcheckout
2. 何かのファイルを適当に修正する
3. git commitする
4. 失敗することを確認
    <img width="861" alt="Pasted image 20231006092417" src="https://github.com/openameba/a11y-guidelines/assets/4669600/4fb4ff60-d1d6-47a9-a0d1-6c0f31ec72ed">
5. このブランチをcheckoutする
6. 何かのファイルを適当に修正する
7. git commitする
8. 成功することを確認
    <img width="370" alt="image" src="https://github.com/openameba/a11y-guidelines/assets/4669600/2ef1a0c8-d1f5-4084-9ade-856a1b4692d3">


## 関連リンク
<!-- 関連するIssueやPull Requestなど -->
近そうなPRとコメント
https://github.com/openameba/a11y-guidelines/pull/197#pullrequestreview-624194351


## 確認項目
Pull Requestを出す前に確認しましょう。

- [x] コミットは適切にまとめられているか
- [x] Pull Requestの概要を適切に書いたか
- [x] レビュワーの指定をしているか
- [x] textlintを実行しエラーが出ていないか
- [ ] Accessibility
  - [ ] altは適切に設定したか([参考(1.1.1 画像に代替テキストを提供する)](https://openameba.github.io/a11y-guidelines/1/1/1/))

## その他
<!-- レビュワーへの申し送りやその他コメント等あれば -->
