### PR TITLE
chore: GitHub Workflowのnodeバージョン指定をpackage.jsonから取得する

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - run: npm ci
       - run: npm run build
       - name: Create CNAME file to apply custom domain

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version-file: 'package.json'
       - run: npm ci
       - run: npm run build
       - name: Create CNAME file to apply custom domain

--- a/.github/workflows/publish-webbundle.yml
+++ b/.github/workflows/publish-webbundle.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: '18.x'
+        node-version-file: 'package.json'
 
     - name: Build Site
       run: |

--- a/.github/workflows/publish-webbundle.yml
+++ b/.github/workflows/publish-webbundle.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: '16.x'
+        node-version: '18.x'
 
     - name: Build Site
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version-file: 'package.json'
           cache: npm
       - run: npm ci
       - run: npm run lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
           cache: npm
       - run: npm ci
       - run: npm run lint


### PR DESCRIPTION
## 概要
https://github.com/openameba/a11y-guidelines/pull/363 で（＋それ以降のminorアップデートでも）18になっていたもののworkflowの方は16のままになっていたので修正しました。
手元では18で確認していたのでまぁ大丈夫でしょう・・:pray:

→package.jsonから取得できるとのことなので修正 🙌 

## 確認

- CIが通るのを見守る
- マージ後deployされたやつがおかしなことにならないことを祈る

## 関連リンク
<!-- 関連するIssueやPull Requestなど -->


## 確認項目
Pull Requestを出す前に確認しましょう。

- [x] コミットは適切にまとめられているか
- [x] Pull Requestの概要を適切に書いたか
- [x] レビュワーの指定をしているか
- [x] textlintを実行しエラーが出ていないか
- [ ] Accessibility
  - [ ] altは適切に設定したか([参考(1.1.1 画像に代替テキストを提供する)](https://openameba.github.io/a11y-guidelines/1/1/1/))

## その他
<!-- レビュワーへの申し送りやその他コメント等あれば -->
