### PR TITLE
fix: summary要素の先頭文字が見切れている

### DIFF
--- a/src/styles/detail/details.css
+++ b/src/styles/detail/details.css
@@ -13,7 +13,7 @@ details + details {
 }
 
 summary {
-  text-indent: -1em;
+  text-indent: -0.8em;
   cursor: pointer;
   font-weight: bold;
   position: relative;


### PR DESCRIPTION
## 概要

折りたたみ表示のsummary要素の先頭文字が見切れているのを修正しました。

before|after
---|---
<img width="1275" alt="修正前のイメージ" src="https://github.com/openameba/a11y-guidelines/assets/4669600/f0429df7-f586-4284-a8c9-4869627779d8">|<img width="1284" alt="修正後のイメージ" src="https://github.com/openameba/a11y-guidelines/assets/4669600/8c4e944b-5817-4d86-973c-e45092513381">
先頭文字が見切れている|先頭文字が全て見えている

## 関連リンク
<!-- 関連するIssueやPull Requestなど -->
https://github.com/openameba/a11y-guidelines/pull/417#discussion_r1354137631


## 確認項目
Pull Requestを出す前に確認しましょう。

- [x] コミットは適切にまとめられているか
- [x] Pull Requestの概要を適切に書いたか
- [x] レビュワーの指定をしているか
- [x] textlintを実行しエラーが出ていないか
- [x] Accessibility
  - [ ] altは適切に設定したか([参考(1.1.1 画像に代替テキストを提供する)](https://openameba.github.io/a11y-guidelines/1/1/1/))

## その他
<!-- レビュワーへの申し送りやその他コメント等あれば -->
