### PR TITLE
chore: fix publish-webbundle

### DIFF
--- a/.github/workflows/publish-webbundle.yml
+++ b/.github/workflows/publish-webbundle.yml
@@ -28,17 +28,9 @@ jobs:
         npm install
         npm run build
 
-    - name: Install go/bundle CLI
-      run: |
-        # Go has been installed at the setup hugo step,
-        # you can run setup-go action if you want to install specific version
-        go get -u github.com/WICG/webpackage/go/bundle/cmd/gen-bundle
-        # Add path to run the package
-        echo "$HOME/go/bin" >> $GITHUB_PATH
-
     - name: Generate Web Bundle 📦
       run: |
-        # Create URL list from the files built by Hugo
+        # Create URL list from the files
         #   - directory index: replacing /index.html with ''
         #     - URL should be exactly the same with the link text in the document
         #   - remove empty lines


### PR DESCRIPTION
## 概要

- ２年ぶりくらいにwebbundle作ろうとしたら[コケてしまった](https://github.com/openameba/a11y-guidelines/actions/runs/6491084777/job/17627852833#step:5:1)
- [GoはたしかHugoのために入れていたはず](https://github.com/openameba/a11y-guidelines/pull/29/files#diff-c04119feaeffc2c216f069aec66797f2f839a2074287060698e3a2440dec8d45R39-R45)なので、今は不要なはず
- Go installを削除

## 関連リンク
<!-- 関連するIssueやPull Requestなど -->


## 確認項目
Pull Requestを出す前に確認しましょう。

- [ ] コミットは適切にまとめられているか
- [ ] Pull Requestの概要を適切に書いたか
- [ ] レビュワーの指定をしているか
- [ ] textlintを実行しエラーが出ていないか
- [ ] Accessibility
  - [ ] altは適切に設定したか([参考(1.1.1 画像に代替テキストを提供する)](https://openameba.github.io/a11y-guidelines/1/1/1/))

## その他
<!-- レビュワーへの申し送りやその他コメント等あれば -->
