### PR TITLE
feat: dialog起動時のフォーカス順序の事例を導入

### DIFF
--- a/src/2/4/3.md
+++ b/src/2/4/3.md
@@ -28,6 +28,21 @@ permalink: "{{ number | scNumberToPath }}/"
 
 ## 実装方法
 
+### Web
+
+モーダルダイアログを起動すると、ダイアログにある最初のフォーカス可能な要素にフォーカスが当たるように実装されている。
+
+```html
+<dialog>
+  <p>サンプルです</p>
+  <form method="dialog">
+    <button autofocus type="button">OK</button>
+  </form>
+</dialog>
+```
+
+spindle-uiでは、[Dialogコンポーネント](https://ameba-spindle.web.app/?path=/docs/dialog--normal)を提供しており、autofocus属性と組み合わせて使用すると良い。
+
 ### Android
 
 コンテンツの表示順序とフォーカスされる順序が一致しておらず、それが意図したものではない場合に以下の実装を使用できる。


### PR DESCRIPTION
## 概要
https://openameba.github.io/a11y-guidelines/2/4/3/ に

https://waic.jp/docs/UNDERSTANDING-WCAG20/navigation-mechanisms-focus-order.html#navigation-mechanisms-focus-order-examples-head の事例を追加しました。

## 関連リンク
<!-- 関連するIssueやPull Requestなど -->
fix:  #9 

## 確認項目
Pull Requestを出す前に確認しましょう。

- [x] コミットは適切にまとめられているか
- [x] Pull Requestの概要を適切に書いたか
- [x] レビュワーの指定をしているか
- [x] textlintを実行しエラーが出ていないか
- [ ] Accessibility
  - [ ] altは適切に設定したか([参考(1.1.1 画像に代替テキストを提供する)](https://openameba.github.io/a11y-guidelines/1/1/1/))

## その他
<!-- レビュワーへの申し送りやその他コメント等あれば -->
