### PR TITLE
fix: 「大きな文字」の基準を日本語の全角文字基準に

### DIFF
--- a/src/1/4/3.md
+++ b/src/1/4/3.md
@@ -22,10 +22,10 @@ permalink: "{{ number | scNumberToPath }}/"
 - 大きな文字の場合、コントラスト比を3:1以上にする
 - それ以外の場合、コントラスト比を4.5:1以上にする
 
-ここで、「大きな文字」とは以下の通り。
+ここでいう「大きな文字」とは以下の通り。Amebaでは主に日本語が用いられているため、日本語の全角文字の場合の基準値を用いている（参考文献を参照）
 
-- 18.5px以上の太字（14pt相当）
-- 24px以上（18pt相当）
+- 24px以上の太字（18pt相当）
+- 29px以上（22pt相当）
 
 ### 例外
 
@@ -65,3 +65,4 @@ Starkの使い方は[色盲・色弱のシミュレーションやコントラ�
 
 - [達成基準 1.4.3: コントラスト (最低限)を理解する](https://waic.jp/docs/WCAG21/Understanding/contrast-minimum.html)
 - [コントラスト - Wikipedia](https://ja.wikipedia.org/wiki/コントラスト)
+- [サイズの大きな (テキスト) (large scale (text)) | 達成基準 1.4.3: コントラスト (最低限)を理解する](https://waic.jp/translations/WCAG21/Understanding/contrast-minimum.html#dfn-large-scale)


### PR DESCRIPTION
## 概要
[1.4.3 テキストや文字画像のコントラストを確保する](https://a11y-guidelines.ameba.design/1/4/3/)の「大きな文字」の基準が英語のサイズから、日本語の全角文字基準のサイズに変更しました。

## 関連リンク
<!-- 関連するIssueやPull Requestなど -->
fix: #433 


## 確認項目
Pull Requestを出す前に確認しましょう。

- [x] コミットは適切にまとめられているか
- [x] Pull Requestの概要を適切に書いたか
- [x] レビュワーの指定をしているか
- [x] textlintを実行しエラーが出ていないか
- [ ] Accessibility
  - [ ] altは適切に設定したか([参考(1.1.1 画像に代替テキストを提供する)](https://openameba.github.io/a11y-guidelines/1/1/1/))

## その他
<!-- レビュワーへの申し送りやその他コメント等あれば -->
