### PR TITLE
Revert "chore(deps): update dependency markdown-it-anchor to v9"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "cssnano": "^7.0.0",
         "husky": "^9.0.0",
         "lint-staged": "^15.0.0",
-        "markdown-it-anchor": "^9.0.0",
+        "markdown-it-anchor": "^8.4.1",
         "npm-run-all2": "^6.0.0",
         "postcss-cli": "^11.0.0",
         "postcss-custom-properties": "^13.0.0",
@@ -5160,9 +5160,9 @@
       }
     },
     "node_modules/markdown-it-anchor": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-9.0.0.tgz",
-      "integrity": "sha512-gf3mP2g4YZ2WhJrYYOCgU6CyyczVAncjkafan0ONM0AtXTTgIeXMw7M+VjDt4EWODxC2GROpAClUuo2iz5+p3A==",
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.4.tgz",
+      "integrity": "sha512-Ul4YVYZNxMJYALpKtu+ZRdrryYt/GlQ5CK+4l1bp/gWXOG2QWElt6AqF3Mih/wfUKdZbNAZVXGR73/n6U/8img==",
       "dev": true,
       "peerDependencies": {
         "@types/markdown-it": "*",
@@ -15007,9 +15007,9 @@
       }
     },
     "markdown-it-anchor": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-9.0.0.tgz",
-      "integrity": "sha512-gf3mP2g4YZ2WhJrYYOCgU6CyyczVAncjkafan0ONM0AtXTTgIeXMw7M+VjDt4EWODxC2GROpAClUuo2iz5+p3A==",
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.4.tgz",
+      "integrity": "sha512-Ul4YVYZNxMJYALpKtu+ZRdrryYt/GlQ5CK+4l1bp/gWXOG2QWElt6AqF3Mih/wfUKdZbNAZVXGR73/n6U/8img==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "cssnano": "^7.0.0",
     "husky": "^9.0.0",
     "lint-staged": "^15.0.0",
-    "markdown-it-anchor": "^9.0.0",
+    "markdown-it-anchor": "^8.4.1",
     "npm-run-all2": "^6.0.0",
     "postcss-cli": "^11.0.0",
     "postcss-custom-properties": "^13.0.0",


### PR DESCRIPTION
Reverts openameba/a11y-guidelines#465