### PR TITLE
chore: split renovate config to file

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,0 +1,15 @@
+{
+  "extends": [
+    "config:base",
+    ":automergePatch",
+    ":label(renovate)",
+    ":preserveSemverRanges",
+    ":timezone(Asia/Tokyo)",
+    "group:linters",
+    "group:postcss"
+  ],
+  "reviewers": [
+    "team:spindle-working-group"
+  ],
+  "prConcurrentLimit": 0
+}

--- a/package.json
+++ b/package.json
@@ -54,28 +54,6 @@
     }
   },
   "private": true,
-  "renovate": {
-    "extends": [
-      "config:base",
-      "group:linters",
-      "group:postcss",
-      ":automergePatch",
-      ":label(renovate)",
-      ":preserveSemverRanges",
-      ":timezone(Asia/Tokyo)"
-    ],
-    "assignees": [
-      "herablog",
-      "hrfmmymt",
-      "masuP9",
-      "nagatsukey",
-      "sasaplus1",
-      "syasuda90",
-      "itsminadesu",
-      "tokimari"
-    ],
-    "assigneesSampleSize": 2
-  },
   "repository": "openameba/a11y-guidelines",
   "scripts": {
     "build": "npm-run-all build:*",


### PR DESCRIPTION
## 概要
https://docs.renovatebot.com/configuration-options/#configuration-options によると package.json の renovate 設定は将来的に削除する予定とのことなので設定を .renovaterc.json に分離しました。

## 関連リンク
<!-- 関連するIssueやPull Requestなど -->

なし

## 確認項目
Pull Requestを出す前に確認しましょう。

- [x] コミットは適切にまとめられているか
- [x] Pull Requestの概要を適切に書いたか
- [x] レビュワーの指定をしているか
- [x] textlintを実行しエラーが出ていないか
- [x] Accessibility
  - [x] altは適切に設定したか([参考(1.1.1 画像に代替テキストを提供する)](https://openameba.github.io/a11y-guidelines/1/1/1/))

## その他
<!-- レビュワーへの申し送りやその他コメント等あれば -->

https://github.com/openameba/spindle/blob/main/.renovaterc.json の設定に似せました。
