### PR TITLE
fix: lint-stagedのtextlintのターゲットをsrc/*.mdに変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   ],
   "license": "SEE LICENSE IN LICENSE.md",
   "lint-staged": {
-    "*.md": "textlint --dry-run",
+    "src/*.md": "textlint --dry-run",
     "*.+(css|js)": "prettier --check",
     "package.json": "npx fixpack --dryRun",
     "yarn.lock": "node -e 'process.exitCode = 1'"


### PR DESCRIPTION
## 概要

src配下以外の `*.md` ファイル（ `CONTRIBUTING.md` など）には 「ですます」口調があるため、当該ファイルを変更後にcommitしようとすると、textlintのエラーが発生します。
textlintは公開面の `*.md` ファイルに適用できれば良いので、 lint-stagedのtextlintのターゲットファイルを `*.md`から`src/*.md`に変更します。

試しに `CONTRIBUTING.md` に差分を作って commit & pushしてCIがパスすることを確認しました✅


## 関連リンク
<!-- 関連するIssueやPull Requestなど -->

- #477 
  - このPRの内容をcommitしたらtextlintエラーになったため、修正しました


## 確認項目
Pull Requestを出す前に確認しましょう。

- [x] コミットは適切にまとめられているか
- [x] Pull Requestの概要を適切に書いたか
- [x] レビュワーの指定をしているか
- [x] textlintを実行しエラーが出ていないか
- [x] Accessibility
  - [ ] altは適切に設定したか([参考(1.1.1 画像に代替テキストを提供する)](https://openameba.github.io/a11y-guidelines/1/1/1/))

## その他
<!-- レビュワーへの申し送りやその他コメント等あれば -->
