### PR TITLE
docs: ローカル開発のURLを修正

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,4 +31,4 @@ $ npm ci
 $ npm start
 ```
 
-するとHTTPサーバーが起動するので、 http://localhost:1313/a11y-guidelines にブラウザからアクセスすると確認ができます。
+するとHTTPサーバーが起動するので、 http://localhost:3000 にブラウザからアクセスすると確認ができます。


### PR DESCRIPTION
## 概要

https://github.com/openameba/a11y-guidelines/pull/147 で11tyに変更になった際にローカル環境のURLが変わりましたが、`CONTRIBUTING.md` の更新が漏れていたため修正します。


## 関連リンク
<!-- 関連するIssueやPull Requestなど -->

- https://github.com/openameba/a11y-guidelines/pull/147

## 確認項目
Pull Requestを出す前に確認しましょう。

- [x] コミットは適切にまとめられているか
- [x] Pull Requestの概要を適切に書いたか
- [ ] レビュワーの指定をしているか
- [x] textlintを実行しエラーが出ていないか
- [x] Accessibility
  - [ ] altは適切に設定したか([参考(1.1.1 画像に代替テキストを提供する)](https://openameba.github.io/a11y-guidelines/1/1/1/))

## その他
<!-- レビュワーへの申し送りやその他コメント等あれば -->
