### PR TITLE
fix: [1.4.3] リンク切れしているtota11yの文章を削除

### DIFF
--- a/src/1/4/3.md
+++ b/src/1/4/3.md
@@ -57,8 +57,6 @@ Starkの使い方は[色盲・色弱のシミュレーションやコントラ�
 
 デバッグ時にChrome DevToolsのAuditsパネルで、Accessibilityにチェックをして監査をすることで、コントラスト比が保たれていないテキストを洗い出せる。
 
-また [tota11y](https://khan.github.io/tota11y/) というツールを使うことでもチェックできる。tota11yは、[Chrome Extension](https://chrome.google.com/webstore/detail/oedofneiplgibimfkccchnimiadcmhpe) としても入手できる。
-
 これらを用いて実装時に適時チェックするものとし、少なくともGitなどのバージョン管理システムでコミットする時に漏れ無くチェックする。
 
 ## 参考文献


### PR DESCRIPTION
## 概要
以下セクションのtota11yのリンクが切れていたので該当文章を削除しました。
[実装時](https://a11y-guidelines.ameba.design/1/4/3/#%E5%AE%9F%E8%A3%85%E6%99%82)

## 関連リンク
<!-- 関連するIssueやPull Requestなど -->
#487 

## 確認項目
Pull Requestを出す前に確認しましょう。

- [x] コミットは適切にまとめられているか
- [x] Pull Requestの概要を適切に書いたか
- [ ] レビュワーの指定をしているか
- [x] textlintを実行しエラーが出ていないか
- [x] Accessibility
  - [x] altは適切に設定したか([参考(1.1.1 画像に代替テキストを提供する)](https://openameba.github.io/a11y-guidelines/1/1/1/))

## その他
<!-- レビュワーへの申し送りやその他コメント等あれば -->
