### PR TITLE
ci: actions/cacheをv4に更新

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,15 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: 'package.json'
-          cache: npm
+      - id: npm-cache-dir
+        run: echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
+      - id: npm-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-${{ github.event_name }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ github.event_name }}-node-
       - run: npm ci
       - run: npm run lint
       - run: npm run build


### PR DESCRIPTION
## 概要
actions/cache@v3の廃止に伴い、1月末までにv4への更新が必要です
setup-nodeのcacheオプションは内部でactions/cache@v3が利用されているため、これをやめて自前でactions/cacheを使います（setup-node側の更新待ちとなり、期限内に柔軟な対応が出来ないため）

## 関連リンク
https://www.notion.so/cyberagent-group/openameba-a11y-guidelines-165b68753fe980209f05f61ec35853f0
https://github.com/actions/toolkit/discussions/1890

## 確認項目
lighthouseのtestワークフローが正常終了していればOKです

## その他
1月中にマージ